### PR TITLE
Pass the emit_context by (non-const) reference

### DIFF
--- a/src/dp_tests/simple_encodable.hpp
+++ b/src/dp_tests/simple_encodable.hpp
@@ -31,12 +31,12 @@ template <>
 class dplx::dp::codec<dp_tests::simple_encodable>
 {
 public:
-    static auto size_of(emit_context const &,
-                        dp_tests::simple_encodable) noexcept -> std::uint64_t
+    static auto size_of(emit_context &, dp_tests::simple_encodable) noexcept
+            -> std::uint64_t
     {
         return 1U;
     }
-    static auto encode(emit_context const &ctx,
+    static auto encode(emit_context &ctx,
                        dp_tests::simple_encodable obj) noexcept -> result<void>
     {
         DPLX_TRY(ctx.out.ensure_size(1U));

--- a/src/dp_tests/test_output_stream.hpp
+++ b/src/dp_tests/test_output_stream.hpp
@@ -96,7 +96,7 @@ public:
     {
     }
 
-    auto as_emit_context() noexcept -> dp::emit_context const &
+    auto as_emit_context() noexcept -> dp::emit_context &
     {
         return *this;
     }
@@ -263,7 +263,7 @@ public:
     {
     }
 
-    auto as_emit_context() noexcept -> dp::emit_context const &
+    auto as_emit_context() noexcept -> dp::emit_context &
     {
         return *this;
     }

--- a/src/dplx/dp/api.hpp
+++ b/src/dplx/dp/api.hpp
@@ -43,13 +43,13 @@ inline constexpr struct encoded_size_of_fn
     {
         using unqualified_type = cncr::remove_cref_t<T>;
         void_stream dummyStream{};
-        emit_context const ctx{dummyStream};
+        emit_context ctx{dummyStream};
         return codec<unqualified_type>::size_of(
                 ctx, static_cast<unqualified_type const &>(value));
     }
     template <typename T>
         requires encodable<cncr::remove_cref_t<T>>
-    constexpr auto operator()(emit_context const &ctx, T &&value) const noexcept
+    constexpr auto operator()(emit_context &ctx, T &&value) const noexcept
     {
         using unqualified_type = cncr::remove_cref_t<T>;
         return codec<unqualified_type>::size_of(
@@ -69,7 +69,7 @@ inline constexpr struct encode_fn final
                  -> result<void>
     {
         auto &&buffer = get_output_buffer(static_cast<OutStream &&>(outStream));
-        emit_context const ctx{static_cast<output_buffer &>(buffer)};
+        emit_context ctx{static_cast<output_buffer &>(buffer)};
         DPLX_TRY(codec<cncr::remove_cref_t<T>>::encode(
                 ctx, static_cast<cncr::remove_cref_t<T> const &>(value)));
         return static_cast<output_buffer &>(buffer).sync_output();
@@ -79,13 +79,13 @@ inline constexpr struct encode_fn final
     inline auto operator()(output_buffer &outStream, T &&value) const noexcept
             -> result<void>
     {
-        emit_context const ctx{outStream};
+        emit_context ctx{outStream};
         return codec<cncr::remove_cref_t<T>>::encode(
                 ctx, static_cast<cncr::remove_cref_t<T> const &>(value));
     }
     template <typename T>
         requires encodable<cncr::remove_cref_t<T>>
-    inline auto operator()(emit_context const &ctx, T &&value) const noexcept
+    inline auto operator()(emit_context &ctx, T &&value) const noexcept
             -> result<void>
     {
         return codec<cncr::remove_cref_t<T>>::encode(

--- a/src/dplx/dp/codecs/auto_enum.hpp
+++ b/src/dplx/dp/codecs/auto_enum.hpp
@@ -21,14 +21,12 @@ template <codable_enum T>
 class codec<T>
 {
 public:
-    static auto size_of(emit_context const &ctx, T value) noexcept
-            -> std::uint64_t
+    static auto size_of(emit_context &ctx, T value) noexcept -> std::uint64_t
     {
         return dp::encoded_size_of(
                 ctx, static_cast<std::underlying_type_t<T>>(value));
     }
-    static auto encode(emit_context const &ctx, T value) noexcept
-            -> result<void>
+    static auto encode(emit_context &ctx, T value) noexcept -> result<void>
     {
         return dp::encode(ctx, static_cast<std::underlying_type_t<T>>(value));
     }

--- a/src/dplx/dp/codecs/auto_object.hpp
+++ b/src/dplx/dp/codecs/auto_object.hpp
@@ -32,7 +32,7 @@ namespace dplx::dp::detail
 template <typename T>
 struct mp_encode_object_property_fn
 {
-    emit_context const &ctx;
+    emit_context &ctx;
     T const &value;
 
     template <typename PropDefType>
@@ -53,7 +53,7 @@ struct mp_encode_object_property_fn
 template <typename T>
 struct mp_size_of_object_property_fn
 {
-    emit_context const &ctx;
+    emit_context &ctx;
     T const &value;
 
     template <typename PropDefType>
@@ -79,7 +79,7 @@ namespace dplx::dp
 
 template <auto const &descriptor>
 inline auto
-encode_object(emit_context const &ctx,
+encode_object(emit_context &ctx,
               detail::descriptor_class_type<descriptor> const &value) noexcept
         -> result<void>
 {
@@ -103,7 +103,7 @@ encode_object(emit_context const &ctx,
 }
 
 template <packable_object T>
-inline auto encode_object(emit_context const &ctx, T const &value) noexcept
+inline auto encode_object(emit_context &ctx, T const &value) noexcept
         -> result<void>
 {
     return dp::encode_object<layout_descriptor_for_v<T>>(ctx, value);
@@ -111,7 +111,7 @@ inline auto encode_object(emit_context const &ctx, T const &value) noexcept
 
 template <auto const &descriptor>
 constexpr auto
-size_of_object(emit_context const &ctx,
+size_of_object(emit_context &ctx,
                detail::descriptor_class_type<descriptor> const &value) noexcept
         -> std::uint64_t
 {
@@ -138,7 +138,7 @@ size_of_object(emit_context const &ctx,
 }
 
 template <packable_object T>
-constexpr auto size_of_object(emit_context const &ctx, T const &value) noexcept
+constexpr auto size_of_object(emit_context &ctx, T const &value) noexcept
         -> std::uint64_t
 {
     return dp::size_of_object<layout_descriptor_for_v<T>>(ctx, value);

--- a/src/dplx/dp/codecs/auto_tuple.hpp
+++ b/src/dplx/dp/codecs/auto_tuple.hpp
@@ -29,7 +29,7 @@ namespace dplx::dp::detail
 template <typename T>
 struct mp_encode_tuple_member_fn
 {
-    emit_context const &ctx;
+    emit_context &ctx;
     T const &value;
 
     template <typename PropDefType>
@@ -44,7 +44,7 @@ struct mp_encode_tuple_member_fn
 template <typename T>
 struct mp_size_of_tuple_element_fn
 {
-    emit_context const &ctx;
+    emit_context &ctx;
     T const &value;
 
     template <typename PropDefType>
@@ -64,7 +64,7 @@ namespace dplx::dp
 
 template <auto const &descriptor>
 inline auto
-encode_tuple(emit_context const &ctx,
+encode_tuple(emit_context &ctx,
              detail::descriptor_class_type<descriptor> const &value) noexcept
         -> result<void>
 {
@@ -85,7 +85,7 @@ encode_tuple(emit_context const &ctx,
 }
 
 template <packable_tuple T>
-inline auto encode_tuple(emit_context const &ctx, T const &value) noexcept
+inline auto encode_tuple(emit_context &ctx, T const &value) noexcept
         -> result<void>
 {
     return dp::encode_tuple<layout_descriptor_for_v<T>>(ctx, value);
@@ -93,7 +93,7 @@ inline auto encode_tuple(emit_context const &ctx, T const &value) noexcept
 
 template <auto const &descriptor>
 inline auto
-size_of_tuple(emit_context const &ctx,
+size_of_tuple(emit_context &ctx,
               detail::descriptor_class_type<descriptor> const &value) noexcept
         -> std::uint64_t
 {
@@ -118,7 +118,7 @@ size_of_tuple(emit_context const &ctx,
 }
 
 template <packable_tuple T>
-inline auto size_of_tuple(emit_context const &ctx, T const &value) noexcept
+inline auto size_of_tuple(emit_context &ctx, T const &value) noexcept
         -> std::uint64_t
 {
     return dp::size_of_tuple<layout_descriptor_for_v<T>>(ctx, value);

--- a/src/dplx/dp/codecs/core.cpp
+++ b/src/dplx/dp/codecs/core.cpp
@@ -15,24 +15,24 @@
 namespace dplx::dp
 {
 
-auto codec<null_type>::size_of(emit_context const &ctx, null_type) noexcept
+auto codec<null_type>::size_of(emit_context &ctx, null_type) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_null(ctx);
 }
-auto codec<null_type>::encode(emit_context const &ctx, null_type) noexcept
+auto codec<null_type>::encode(emit_context &ctx, null_type) noexcept
         -> result<void>
 {
     return dp::emit_null(ctx);
 }
 
-auto codec<signed char>::size_of(emit_context const &ctx,
-                                 signed char value) noexcept -> std::uint64_t
+auto codec<signed char>::size_of(emit_context &ctx, signed char value) noexcept
+        -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<signed char>::encode(emit_context const &ctx,
-                                signed char value) noexcept -> result<void>
+auto codec<signed char>::encode(emit_context &ctx, signed char value) noexcept
+        -> result<void>
 {
     return dp::emit_integer(ctx, value);
 }
@@ -41,13 +41,13 @@ auto codec<signed char>::decode(parse_context &ctx, signed char &value) noexcept
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<unsigned char>::size_of(emit_context const &ctx,
+auto codec<unsigned char>::size_of(emit_context &ctx,
                                    unsigned char value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<unsigned char>::encode(emit_context const &ctx,
+auto codec<unsigned char>::encode(emit_context &ctx,
                                   unsigned char value) noexcept -> result<void>
 {
     return dp::emit_integer(ctx, value);
@@ -57,12 +57,12 @@ auto codec<unsigned char>::decode(parse_context &ctx,
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<short>::size_of(emit_context const &ctx, short value) noexcept
+auto codec<short>::size_of(emit_context &ctx, short value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<short>::encode(emit_context const &ctx, short value) noexcept
+auto codec<short>::encode(emit_context &ctx, short value) noexcept
         -> result<void>
 {
     return dp::emit_integer(ctx, value);
@@ -72,13 +72,13 @@ auto codec<short>::decode(parse_context &ctx, short &value) noexcept
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<unsigned short>::size_of(emit_context const &ctx,
+auto codec<unsigned short>::size_of(emit_context &ctx,
                                     unsigned short value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<unsigned short>::encode(emit_context const &ctx,
+auto codec<unsigned short>::encode(emit_context &ctx,
                                    unsigned short value) noexcept
         -> result<void>
 {
@@ -90,13 +90,11 @@ auto codec<unsigned short>::decode(parse_context &ctx,
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<int>::size_of(emit_context const &ctx, int value) noexcept
-        -> std::uint64_t
+auto codec<int>::size_of(emit_context &ctx, int value) noexcept -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<int>::encode(emit_context const &ctx, int value) noexcept
-        -> result<void>
+auto codec<int>::encode(emit_context &ctx, int value) noexcept -> result<void>
 {
     return dp::emit_integer(ctx, value);
 }
@@ -104,12 +102,12 @@ auto codec<int>::decode(parse_context &ctx, int &value) noexcept -> result<void>
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<unsigned>::size_of(emit_context const &ctx, unsigned value) noexcept
+auto codec<unsigned>::size_of(emit_context &ctx, unsigned value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<unsigned>::encode(emit_context const &ctx, unsigned value) noexcept
+auto codec<unsigned>::encode(emit_context &ctx, unsigned value) noexcept
         -> result<void>
 {
     return dp::emit_integer(ctx, value);
@@ -119,13 +117,12 @@ auto codec<unsigned>::decode(parse_context &ctx, unsigned &value) noexcept
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<long>::size_of(emit_context const &ctx, long value) noexcept
+auto codec<long>::size_of(emit_context &ctx, long value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<long>::encode(emit_context const &ctx, long value) noexcept
-        -> result<void>
+auto codec<long>::encode(emit_context &ctx, long value) noexcept -> result<void>
 {
     return dp::emit_integer(ctx, value);
 }
@@ -134,13 +131,13 @@ auto codec<long>::decode(parse_context &ctx, long &value) noexcept
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<unsigned long>::size_of(emit_context const &ctx,
+auto codec<unsigned long>::size_of(emit_context &ctx,
                                    unsigned long value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<unsigned long>::encode(emit_context const &ctx,
+auto codec<unsigned long>::encode(emit_context &ctx,
                                   unsigned long value) noexcept -> result<void>
 {
     return dp::emit_integer(ctx, value);
@@ -150,12 +147,12 @@ auto codec<unsigned long>::decode(parse_context &ctx,
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<long long>::size_of(emit_context const &ctx,
-                               long long value) noexcept -> std::uint64_t
+auto codec<long long>::size_of(emit_context &ctx, long long value) noexcept
+        -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<long long>::encode(emit_context const &ctx, long long value) noexcept
+auto codec<long long>::encode(emit_context &ctx, long long value) noexcept
         -> result<void>
 {
     return dp::emit_integer(ctx, value);
@@ -165,13 +162,13 @@ auto codec<long long>::decode(parse_context &ctx, long long &value) noexcept
 {
     return dp::parse_integer(ctx, value);
 }
-auto codec<unsigned long long>::size_of(emit_context const &ctx,
+auto codec<unsigned long long>::size_of(emit_context &ctx,
                                         unsigned long long value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_integer(ctx, value);
 }
-auto codec<unsigned long long>::encode(emit_context const &ctx,
+auto codec<unsigned long long>::encode(emit_context &ctx,
                                        unsigned long long value) noexcept
         -> result<void>
 {
@@ -184,13 +181,12 @@ auto codec<unsigned long long>::decode(parse_context &ctx,
     return dp::parse_integer(ctx, value);
 }
 
-auto codec<bool>::size_of(emit_context const &ctx, bool value) noexcept
+auto codec<bool>::size_of(emit_context &ctx, bool value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_boolean(ctx, value);
 }
-auto codec<bool>::encode(emit_context const &ctx, bool value) noexcept
-        -> result<void>
+auto codec<bool>::encode(emit_context &ctx, bool value) noexcept -> result<void>
 {
     return dp::emit_boolean(ctx, value);
 }
@@ -200,12 +196,12 @@ auto codec<bool>::decode(parse_context &ctx, bool &value) noexcept
     return dp::parse_boolean(ctx, value);
 }
 
-auto codec<float>::size_of(emit_context const &ctx, float value) noexcept
+auto codec<float>::size_of(emit_context &ctx, float value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_float_single(ctx, value);
 }
-auto codec<float>::encode(emit_context const &ctx, float value) noexcept
+auto codec<float>::encode(emit_context &ctx, float value) noexcept
         -> result<void>
 {
     return dp::emit_float_single(ctx, value);
@@ -216,12 +212,12 @@ auto codec<float>::decode(parse_context &ctx, float &value) noexcept
     return dp::parse_floating_point<float>(ctx, value);
 }
 
-auto codec<double>::size_of(emit_context const &ctx, double value) noexcept
+auto codec<double>::size_of(emit_context &ctx, double value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_float_double(ctx, value);
 }
-auto codec<double>::encode(emit_context const &ctx, double value) noexcept
+auto codec<double>::encode(emit_context &ctx, double value) noexcept
         -> result<void>
 {
     return dp::emit_float_double(ctx, value);

--- a/src/dplx/dp/codecs/core.hpp
+++ b/src/dplx/dp/codecs/core.hpp
@@ -23,19 +23,17 @@ template <>
 class codec<null_type>
 {
 public:
-    static auto size_of(emit_context const &ctx, null_type) noexcept
-            -> std::uint64_t;
-    static auto encode(emit_context const &ctx, null_type) noexcept
-            -> result<void>;
+    static auto size_of(emit_context &ctx, null_type) noexcept -> std::uint64_t;
+    static auto encode(emit_context &ctx, null_type) noexcept -> result<void>;
 };
 
 template <>
 class codec<signed char>
 {
 public:
-    static auto size_of(emit_context const &ctx, signed char value) noexcept
+    static auto size_of(emit_context &ctx, signed char value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, signed char value) noexcept
+    static auto encode(emit_context &ctx, signed char value) noexcept
             -> result<void>;
     static auto decode(parse_context &ctx, signed char &outValue) noexcept
             -> result<void>;
@@ -44,9 +42,9 @@ template <>
 class codec<unsigned char>
 {
 public:
-    static auto size_of(emit_context const &ctx, unsigned char value) noexcept
+    static auto size_of(emit_context &ctx, unsigned char value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, unsigned char value) noexcept
+    static auto encode(emit_context &ctx, unsigned char value) noexcept
             -> result<void>;
     static auto decode(parse_context &ctx, unsigned char &outValue) noexcept
             -> result<void>;
@@ -55,10 +53,9 @@ template <>
 class codec<short>
 {
 public:
-    static auto size_of(emit_context const &ctx, short value) noexcept
+    static auto size_of(emit_context &ctx, short value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, short value) noexcept
-            -> result<void>;
+    static auto encode(emit_context &ctx, short value) noexcept -> result<void>;
     static auto decode(parse_context &ctx, short &outValue) noexcept
             -> result<void>;
 };
@@ -66,9 +63,9 @@ template <>
 class codec<unsigned short>
 {
 public:
-    static auto size_of(emit_context const &ctx, unsigned short value) noexcept
+    static auto size_of(emit_context &ctx, unsigned short value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, unsigned short value) noexcept
+    static auto encode(emit_context &ctx, unsigned short value) noexcept
             -> result<void>;
     static auto decode(parse_context &ctx, unsigned short &outValue) noexcept
             -> result<void>;
@@ -77,10 +74,8 @@ template <>
 class codec<int>
 {
 public:
-    static auto size_of(emit_context const &ctx, int value) noexcept
-            -> std::uint64_t;
-    static auto encode(emit_context const &ctx, int value) noexcept
-            -> result<void>;
+    static auto size_of(emit_context &ctx, int value) noexcept -> std::uint64_t;
+    static auto encode(emit_context &ctx, int value) noexcept -> result<void>;
     static auto decode(parse_context &ctx, int &outValue) noexcept
             -> result<void>;
 };
@@ -88,9 +83,9 @@ template <>
 class codec<unsigned>
 {
 public:
-    static auto size_of(emit_context const &ctx, unsigned value) noexcept
+    static auto size_of(emit_context &ctx, unsigned value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, unsigned value) noexcept
+    static auto encode(emit_context &ctx, unsigned value) noexcept
             -> result<void>;
     static auto decode(parse_context &ctx, unsigned &outValue) noexcept
             -> result<void>;
@@ -99,10 +94,9 @@ template <>
 class codec<long>
 {
 public:
-    static auto size_of(emit_context const &ctx, long value) noexcept
+    static auto size_of(emit_context &ctx, long value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, long value) noexcept
-            -> result<void>;
+    static auto encode(emit_context &ctx, long value) noexcept -> result<void>;
     static auto decode(parse_context &ctx, long &outValue) noexcept
             -> result<void>;
 };
@@ -110,9 +104,9 @@ template <>
 class codec<unsigned long>
 {
 public:
-    static auto size_of(emit_context const &ctx, unsigned long value) noexcept
+    static auto size_of(emit_context &ctx, unsigned long value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, unsigned long value) noexcept
+    static auto encode(emit_context &ctx, unsigned long value) noexcept
             -> result<void>;
     static auto decode(parse_context &ctx, unsigned long &outValue) noexcept
             -> result<void>;
@@ -121,9 +115,9 @@ template <>
 class codec<long long>
 {
 public:
-    static auto size_of(emit_context const &ctx, long long value) noexcept
+    static auto size_of(emit_context &ctx, long long value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, long long value) noexcept
+    static auto encode(emit_context &ctx, long long value) noexcept
             -> result<void>;
     static auto decode(parse_context &ctx, long long &outValue) noexcept
             -> result<void>;
@@ -132,10 +126,10 @@ template <>
 class codec<unsigned long long>
 {
 public:
-    static auto size_of(emit_context const &ctx,
-                        unsigned long long value) noexcept -> std::uint64_t;
-    static auto encode(emit_context const &ctx,
-                       unsigned long long value) noexcept -> result<void>;
+    static auto size_of(emit_context &ctx, unsigned long long value) noexcept
+            -> std::uint64_t;
+    static auto encode(emit_context &ctx, unsigned long long value) noexcept
+            -> result<void>;
     static auto decode(parse_context &ctx,
                        unsigned long long &outValue) noexcept -> result<void>;
 };
@@ -144,10 +138,9 @@ template <>
 class codec<bool>
 {
 public:
-    static auto size_of(emit_context const &ctx, bool value) noexcept
+    static auto size_of(emit_context &ctx, bool value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, bool value) noexcept
-            -> result<void>;
+    static auto encode(emit_context &ctx, bool value) noexcept -> result<void>;
     static auto decode(parse_context &ctx, bool &value) noexcept
             -> result<void>;
 };
@@ -156,10 +149,9 @@ template <>
 class codec<float>
 {
 public:
-    static auto size_of(emit_context const &ctx, float value) noexcept
+    static auto size_of(emit_context &ctx, float value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, float value) noexcept
-            -> result<void>;
+    static auto encode(emit_context &ctx, float value) noexcept -> result<void>;
     static auto decode(parse_context &ctx, float &value) noexcept
             -> result<void>;
 };
@@ -168,9 +160,9 @@ template <>
 class codec<double>
 {
 public:
-    static auto size_of(emit_context const &ctx, double value) noexcept
+    static auto size_of(emit_context &ctx, double value) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx, double value) noexcept
+    static auto encode(emit_context &ctx, double value) noexcept
             -> result<void>;
     static auto decode(parse_context &ctx, double &value) noexcept
             -> result<void>;

--- a/src/dplx/dp/codecs/fixed_u8string.cpp
+++ b/src/dplx/dp/codecs/fixed_u8string.cpp
@@ -20,13 +20,13 @@
 namespace dplx::dp::detail
 {
 
-auto fixed_u8string_codec_base::size_of(emit_context const &ctx,
+auto fixed_u8string_codec_base::size_of(emit_context &ctx,
                                         std::u8string_view value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_u8string(ctx, value.size());
 }
-auto fixed_u8string_codec_base::encode(emit_context const &ctx,
+auto fixed_u8string_codec_base::encode(emit_context &ctx,
                                        std::u8string_view value) noexcept
         -> result<void>
 {

--- a/src/dplx/dp/codecs/fixed_u8string.hpp
+++ b/src/dplx/dp/codecs/fixed_u8string.hpp
@@ -179,10 +179,10 @@ namespace detail
 class fixed_u8string_codec_base
 {
 public:
-    static auto size_of(emit_context const &ctx,
-                        std::u8string_view value) noexcept -> std::uint64_t;
-    static auto encode(emit_context const &ctx,
-                       std::u8string_view value) noexcept -> result<void>;
+    static auto size_of(emit_context &ctx, std::u8string_view value) noexcept
+            -> std::uint64_t;
+    static auto encode(emit_context &ctx, std::u8string_view value) noexcept
+            -> result<void>;
 };
 
 auto decode_fixed_u8string(parse_context &ctx, char8_t *out, unsigned &outlen)

--- a/src/dplx/dp/codecs/std-chrono.hpp
+++ b/src/dplx/dp/codecs/std-chrono.hpp
@@ -24,13 +24,13 @@ template <typename Rep, typename Period>
 class codec<std::chrono::duration<Rep, Period>>
 {
 public:
-    static auto size_of(emit_context const &ctx,
+    static auto size_of(emit_context &ctx,
                         std::chrono::duration<Rep, Period> value) noexcept
             -> std::uint64_t
     {
         return dp::item_size_of_integer(ctx, value.count());
     }
-    static auto encode(emit_context const &ctx,
+    static auto encode(emit_context &ctx,
                        std::chrono::duration<Rep, Period> value) noexcept
             -> result<void>
     {

--- a/src/dplx/dp/codecs/std-container.hpp
+++ b/src/dplx/dp/codecs/std-container.hpp
@@ -147,12 +147,12 @@ template <range R>
 class codec<R>
 {
 public:
-    static auto size_of(emit_context const &ctx, R const &value) noexcept
+    static auto size_of(emit_context &ctx, R const &value) noexcept
             -> std::uint64_t
     {
         return dp::item_size_of_binary(ctx, std::ranges::size(value));
     }
-    static auto encode(emit_context const &ctx, R const &value) noexcept
+    static auto encode(emit_context &ctx, R const &value) noexcept
             -> result<void>
     {
         return dp::emit_binary(ctx, std::ranges::data(value),
@@ -197,7 +197,7 @@ template <range R>
 class codec<R>
 {
 public:
-    static auto size_of(emit_context const &ctx, R const &vs) noexcept
+    static auto size_of(emit_context &ctx, R const &vs) noexcept
             -> std::uint64_t
         requires std::ranges::input_range<R>
               && encodable<std::ranges::range_value_t<R>>
@@ -212,8 +212,7 @@ public:
             return dp::item_size_of_array(ctx, vs, dp::encoded_size_of);
         }
     }
-    static auto encode(emit_context const &ctx, R const &vs) noexcept
-            -> result<void>
+    static auto encode(emit_context &ctx, R const &vs) noexcept -> result<void>
         requires std::ranges::input_range<R>
               && encodable<std::ranges::range_value_t<R>>
     {
@@ -307,7 +306,7 @@ template <mapping_associative_container C>
 class codec<C>
 {
 public:
-    static auto size_of(emit_context const &ctx, C const &vs) noexcept
+    static auto size_of(emit_context &ctx, C const &vs) noexcept
             -> std::uint64_t
         requires encodable<typename C::key_type>
               && encodable<typename C::mapped_type>
@@ -321,8 +320,7 @@ public:
             return dp::item_size_of_map(ctx, vs, size_of_pair);
         }
     }
-    static auto encode(emit_context const &ctx, C const &vs) noexcept
-            -> result<void>
+    static auto encode(emit_context &ctx, C const &vs) noexcept -> result<void>
         requires encodable<typename C::key_type>
               && encodable<typename C::mapped_type>
     {
@@ -345,7 +343,7 @@ public:
     }
 
 private:
-    static auto size_of_pair(emit_context const &ctx,
+    static auto size_of_pair(emit_context &ctx,
                              typename C::value_type const &pair) noexcept
             -> std::uint64_t
         requires encodable<typename C::key_type>
@@ -354,7 +352,7 @@ private:
         auto const &[key, mapped] = pair;
         return dp::encoded_size_of(ctx, key) + dp::encoded_size_of(ctx, mapped);
     }
-    static auto encode_pair(emit_context const &ctx,
+    static auto encode_pair(emit_context &ctx,
                             typename C::value_type const &pair) noexcept
             -> result<void>
         requires encodable<typename C::key_type>
@@ -407,13 +405,13 @@ template <typename T>
 class fixed_size_binary_item_container_codec
 {
 public:
-    static auto size_of(emit_context const &ctx,
+    static auto size_of(emit_context &ctx,
                         std::span<std::byte const> value) noexcept
             -> std::uint64_t
     {
         return dp::item_size_of_binary(ctx, value.size());
     }
-    static auto encode(emit_context const &ctx,
+    static auto encode(emit_context &ctx,
                        std::span<std::byte const> value) noexcept
             -> result<void>
     {
@@ -442,13 +440,13 @@ template <typename T>
 class fixed_size_container_codec
 {
 public:
-    static auto size_of(emit_context const &ctx, std::span<T const> vs) noexcept
+    static auto size_of(emit_context &ctx, std::span<T const> vs) noexcept
             -> std::uint64_t
         requires encodable<T>
     {
         return dp::item_size_of_array(ctx, vs, dp::encoded_size_of);
     }
-    static auto encode(emit_context const &ctx, std::span<T const> vs) noexcept
+    static auto encode(emit_context &ctx, std::span<T const> vs) noexcept
             -> result<void>
         requires encodable<T>
     {
@@ -489,12 +487,12 @@ class fixed_size_associative_container_codec
     using mapped_type = std::tuple_element_t<1U, T>;
 
 public:
-    static auto size_of(emit_context const &ctx, std::span<T const> vs) noexcept
+    static auto size_of(emit_context &ctx, std::span<T const> vs) noexcept
             -> std::uint64_t requires(encodable_pair<T>)
     {
         return dp::item_size_of_map(ctx, vs, item_size_of_pair);
     }
-    static auto encode(emit_context const &ctx, std::span<T const> vs) noexcept
+    static auto encode(emit_context &ctx, std::span<T const> vs) noexcept
             -> result<void>
         requires(encodable_pair<T>)
     {
@@ -518,13 +516,13 @@ public:
     }
 
 private:
-    static auto item_size_of_pair(emit_context const &ctx,
+    static auto item_size_of_pair(emit_context &ctx,
                                   T const &value) noexcept -> result<void>
     {
         auto const &[key, mapped] = value;
         return encoded_size_of(ctx, key) + encoded_size_of(ctx, mapped);
     }
-    static auto encode_pair(emit_context const &ctx, T const &value) noexcept
+    static auto encode_pair(emit_context &ctx, T const &value) noexcept
             -> result<void>
     {
         auto const &[key, mapped] = value;

--- a/src/dplx/dp/codecs/std-filesystem.cpp
+++ b/src/dplx/dp/codecs/std-filesystem.cpp
@@ -15,7 +15,7 @@
 namespace dplx::dp
 {
 auto codec<std::filesystem::path>::size_of(
-        emit_context const &ctx, std::filesystem::path const &path) noexcept
+        emit_context &ctx, std::filesystem::path const &path) noexcept
         -> std::uint64_t
 try
 {
@@ -27,7 +27,7 @@ catch (...)
     return 0U;
 }
 auto codec<std::filesystem::path>::encode(
-        emit_context const &ctx, std::filesystem::path const &path) noexcept
+        emit_context &ctx, std::filesystem::path const &path) noexcept
         -> result<void>
 try
 {

--- a/src/dplx/dp/codecs/std-filesystem.hpp
+++ b/src/dplx/dp/codecs/std-filesystem.hpp
@@ -19,10 +19,10 @@ template <>
 class codec<std::filesystem::path>
 {
 public:
-    static auto size_of(emit_context const &ctx,
+    static auto size_of(emit_context &ctx,
                         std::filesystem::path const &path) noexcept
             -> std::uint64_t;
-    static auto encode(emit_context const &ctx,
+    static auto encode(emit_context &ctx,
                        std::filesystem::path const &path) noexcept
             -> result<void>;
     static auto decode(parse_context &ctx, std::filesystem::path &path) noexcept

--- a/src/dplx/dp/codecs/std-string.cpp
+++ b/src/dplx/dp/codecs/std-string.cpp
@@ -15,26 +15,26 @@
 namespace dplx::dp
 {
 
-auto codec<std::u8string_view>::size_of(emit_context const &ctx,
+auto codec<std::u8string_view>::size_of(emit_context &ctx,
                                         std::u8string_view value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_u8string(ctx, value.size());
 }
-auto codec<std::u8string_view>::encode(emit_context const &ctx,
+auto codec<std::u8string_view>::encode(emit_context &ctx,
                                        std::u8string_view value) noexcept
         -> result<void>
 {
     return dp::emit_u8string(ctx, value.data(), value.size());
 }
 
-auto codec<std::u8string>::size_of(emit_context const &ctx,
+auto codec<std::u8string>::size_of(emit_context &ctx,
                                    std::u8string const &value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_u8string(ctx, value.size());
 }
-auto codec<std::u8string>::encode(emit_context const &ctx,
+auto codec<std::u8string>::encode(emit_context &ctx,
                                   std::u8string const &value) noexcept
         -> result<void>
 {
@@ -48,26 +48,26 @@ auto codec<std::u8string>::decode(parse_context &ctx,
     return oc::success();
 }
 
-auto codec<std::string_view>::size_of(emit_context const &ctx,
+auto codec<std::string_view>::size_of(emit_context &ctx,
                                       std::string_view value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_u8string(ctx, value.size());
 }
-auto codec<std::string_view>::encode(emit_context const &ctx,
+auto codec<std::string_view>::encode(emit_context &ctx,
                                      std::string_view value) noexcept
         -> result<void>
 {
     return dp::emit_u8string(ctx, value.data(), value.size());
 }
 
-auto codec<std::string>::size_of(emit_context const &ctx,
+auto codec<std::string>::size_of(emit_context &ctx,
                                  std::string const &value) noexcept
         -> std::uint64_t
 {
     return dp::item_size_of_u8string(ctx, value.size());
 }
-auto codec<std::string>::encode(emit_context const &ctx,
+auto codec<std::string>::encode(emit_context &ctx,
                                 std::string const &value) noexcept
         -> result<void>
 {

--- a/src/dplx/dp/codecs/std-string.hpp
+++ b/src/dplx/dp/codecs/std-string.hpp
@@ -20,20 +20,20 @@ template <>
 class codec<std::u8string_view>
 {
 public:
-    static auto size_of(emit_context const &ctx,
-                        std::u8string_view value) noexcept -> std::uint64_t;
-    static auto encode(emit_context const &ctx,
-                       std::u8string_view value) noexcept -> result<void>;
+    static auto size_of(emit_context &ctx, std::u8string_view value) noexcept
+            -> std::uint64_t;
+    static auto encode(emit_context &ctx, std::u8string_view value) noexcept
+            -> result<void>;
 };
 
 template <>
 class codec<std::u8string>
 {
 public:
-    static auto size_of(emit_context const &ctx,
-                        std::u8string const &value) noexcept -> std::uint64_t;
-    static auto encode(emit_context const &ctx,
-                       std::u8string const &value) noexcept -> result<void>;
+    static auto size_of(emit_context &ctx, std::u8string const &value) noexcept
+            -> std::uint64_t;
+    static auto encode(emit_context &ctx, std::u8string const &value) noexcept
+            -> result<void>;
     static auto decode(parse_context &ctx, std::u8string &value) noexcept
             -> result<void>;
 };
@@ -42,9 +42,9 @@ template <>
 class codec<std::string_view>
 {
 public:
-    static auto size_of(emit_context const &ctx,
-                        std::string_view value) noexcept -> std::uint64_t;
-    static auto encode(emit_context const &ctx, std::string_view value) noexcept
+    static auto size_of(emit_context &ctx, std::string_view value) noexcept
+            -> std::uint64_t;
+    static auto encode(emit_context &ctx, std::string_view value) noexcept
             -> result<void>;
 };
 
@@ -52,10 +52,10 @@ template <>
 class codec<std::string>
 {
 public:
-    static auto size_of(emit_context const &ctx,
-                        std::string const &value) noexcept -> std::uint64_t;
-    static auto encode(emit_context const &ctx,
-                       std::string const &value) noexcept -> result<void>;
+    static auto size_of(emit_context &ctx, std::string const &value) noexcept
+            -> std::uint64_t;
+    static auto encode(emit_context &ctx, std::string const &value) noexcept
+            -> result<void>;
     static auto decode(parse_context &ctx, std::string &value) noexcept
             -> result<void>;
 };

--- a/src/dplx/dp/concepts.hpp
+++ b/src/dplx/dp/concepts.hpp
@@ -23,7 +23,7 @@ namespace dplx::dp
 // clang-format off
 template <typename T>
 concept encodable
-    = requires(T const t, emit_context const ctx)
+    = requires(T const t, emit_context ctx)
     {
         requires !std::is_reference_v<T>;
         requires !std::is_pointer_v<T>;

--- a/src/dplx/dp/items/emit_core.hpp
+++ b/src/dplx/dp/items/emit_core.hpp
@@ -139,7 +139,7 @@ namespace dplx::dp
 {
 
 template <detail::encodable_int T>
-inline auto emit_integer(emit_context const &ctx, T const value) noexcept
+inline auto emit_integer(emit_context &ctx, T const value) noexcept
         -> result<void>
 {
     using code_type = detail::encoder_uint_t<T>;
@@ -165,7 +165,7 @@ inline auto emit_integer(emit_context const &ctx, T const value) noexcept
 }
 
 template <detail::encodable_int T>
-inline auto emit_binary(emit_context const &ctx, T const byteSize) noexcept
+inline auto emit_binary(emit_context &ctx, T const byteSize) noexcept
         -> result<void>
 {
     using code_type = detail::encoder_uint_t<T>;
@@ -173,7 +173,7 @@ inline auto emit_binary(emit_context const &ctx, T const byteSize) noexcept
     return detail::store_var_uint<code_type>(
             ctx.out, static_cast<code_type>(byteSize), type_code::binary);
 }
-inline auto emit_binary(emit_context const &ctx,
+inline auto emit_binary(emit_context &ctx,
                         std::byte const *data,
                         std::size_t size) noexcept -> result<void>
 {
@@ -181,23 +181,22 @@ inline auto emit_binary(emit_context const &ctx,
                                                  type_code::binary));
     return ctx.out.bulk_write(data, size);
 }
-inline auto emit_binary_indefinite(emit_context const &ctx) noexcept
-        -> result<void>
+inline auto emit_binary_indefinite(emit_context &ctx) noexcept -> result<void>
 {
     return detail::store_inline_value(ctx.out, detail::indefinite_add_info,
                                       type_code::binary);
 }
 
 template <detail::encodable_int T>
-inline auto emit_u8string(emit_context const &ctx,
-                          T const numCodeUnits) noexcept -> result<void>
+inline auto emit_u8string(emit_context &ctx, T const numCodeUnits) noexcept
+        -> result<void>
 {
     using code_type = detail::encoder_uint_t<T>;
     assert(numCodeUnits >= 0);
     return detail::store_var_uint<code_type>(
             ctx.out, static_cast<code_type>(numCodeUnits), type_code::text);
 }
-inline auto emit_u8string(emit_context const &ctx,
+inline auto emit_u8string(emit_context &ctx,
                           char8_t const *data,
                           std::size_t size) noexcept -> result<void>
 {
@@ -206,7 +205,7 @@ inline auto emit_u8string(emit_context const &ctx,
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return ctx.out.bulk_write(reinterpret_cast<std::byte const *>(data), size);
 }
-inline auto emit_u8string(emit_context const &ctx,
+inline auto emit_u8string(emit_context &ctx,
                           char const *data,
                           std::size_t size) noexcept -> result<void>
 {
@@ -215,15 +214,14 @@ inline auto emit_u8string(emit_context const &ctx,
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return ctx.out.bulk_write(reinterpret_cast<std::byte const *>(data), size);
 }
-inline auto emit_u8string_indefinite(emit_context const &ctx) noexcept
-        -> result<void>
+inline auto emit_u8string_indefinite(emit_context &ctx) noexcept -> result<void>
 {
     return detail::store_inline_value(ctx.out, detail::indefinite_add_info,
                                       type_code::text);
 }
 
 template <detail::encodable_int T>
-inline auto emit_array(emit_context const &ctx, T const numElements) noexcept
+inline auto emit_array(emit_context &ctx, T const numElements) noexcept
         -> result<void>
 {
     using code_type = detail::encoder_uint_t<T>;
@@ -231,15 +229,14 @@ inline auto emit_array(emit_context const &ctx, T const numElements) noexcept
     return detail::store_var_uint<code_type>(
             ctx.out, static_cast<code_type>(numElements), type_code::array);
 }
-inline auto emit_array_indefinite(emit_context const &ctx) noexcept
-        -> result<void>
+inline auto emit_array_indefinite(emit_context &ctx) noexcept -> result<void>
 {
     return detail::store_inline_value(ctx.out, detail::indefinite_add_info,
                                       type_code::array);
 }
 
 template <detail::encodable_int T>
-inline auto emit_map(emit_context const &ctx, T const numElements) noexcept
+inline auto emit_map(emit_context &ctx, T const numElements) noexcept
         -> result<void>
 {
     using code_type = detail::encoder_uint_t<T>;
@@ -247,15 +244,14 @@ inline auto emit_map(emit_context const &ctx, T const numElements) noexcept
     return detail::store_var_uint<code_type>(
             ctx.out, static_cast<code_type>(numElements), type_code::map);
 }
-inline auto emit_map_indefinite(emit_context const &ctx) noexcept
-        -> result<void>
+inline auto emit_map_indefinite(emit_context &ctx) noexcept -> result<void>
 {
     return detail::store_inline_value(ctx.out, detail::indefinite_add_info,
                                       type_code::map);
 }
 
 template <detail::encodable_int T>
-inline auto emit_tag(emit_context const &ctx, T const tagValue) noexcept
+inline auto emit_tag(emit_context &ctx, T const tagValue) noexcept
         -> result<void>
 {
     using code_type = detail::encoder_uint_t<T>;
@@ -264,7 +260,7 @@ inline auto emit_tag(emit_context const &ctx, T const tagValue) noexcept
             ctx.out, static_cast<code_type>(tagValue), type_code::tag);
 }
 
-[[nodiscard]] inline auto emit_boolean(emit_context const &ctx,
+[[nodiscard]] inline auto emit_boolean(emit_context &ctx,
                                        bool const value) noexcept
         -> result<void>
 {
@@ -272,8 +268,8 @@ inline auto emit_tag(emit_context const &ctx, T const tagValue) noexcept
                                       type_code::bool_false);
 }
 
-inline auto emit_float_single(emit_context const &ctx,
-                              float const value) noexcept -> result<void>
+inline auto emit_float_single(emit_context &ctx, float const value) noexcept
+        -> result<void>
 {
     constexpr auto encodedSize = 1U + sizeof(value);
     if (ctx.out.size() < encodedSize) [[unlikely]]
@@ -290,8 +286,8 @@ inline auto emit_float_single(emit_context const &ctx,
     return oc::success();
 }
 
-inline auto emit_float_double(emit_context const &ctx,
-                              double const value) noexcept -> result<void>
+inline auto emit_float_double(emit_context &ctx, double const value) noexcept
+        -> result<void>
 {
     constexpr auto encodedSize = 1U + sizeof(value);
     if (ctx.out.size() < encodedSize) [[unlikely]]
@@ -308,15 +304,15 @@ inline auto emit_float_double(emit_context const &ctx,
     return oc::success();
 }
 
-inline auto emit_null(emit_context const &ctx) noexcept -> result<void>
+inline auto emit_null(emit_context &ctx) noexcept -> result<void>
 {
     return detail::store_inline_value(ctx.out, 0U, type_code::null);
 }
-inline auto emit_undefined(emit_context const &ctx) noexcept -> result<void>
+inline auto emit_undefined(emit_context &ctx) noexcept -> result<void>
 {
     return detail::store_inline_value(ctx.out, 0U, type_code::undefined);
 }
-inline auto emit_break(emit_context const &ctx) noexcept -> result<void>
+inline auto emit_break(emit_context &ctx) noexcept -> result<void>
 {
     return detail::store_inline_value(ctx.out, 0U, type_code::special_break);
 }

--- a/src/dplx/dp/items/emit_core.test.cpp
+++ b/src/dplx/dp/items/emit_core.test.cpp
@@ -37,7 +37,7 @@ TEST_CASE("boolean emits correctly")
     std::vector<std::byte> encodingBuffer(sample.encoded_length);
     dp::memory_output_stream outputStream(encodingBuffer);
 
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
     REQUIRE(emit_boolean(ctx, sample.value));
 
     CHECK(std::ranges::equal(outputStream.written(), sample.encoded_bytes()));
@@ -64,7 +64,7 @@ TEMPLATE_TEST_CASE("positive integers emit correctly",
         std::vector<std::byte> encodingBuffer(sample.encoded_length);
         dp::memory_output_stream outputStream(encodingBuffer);
 
-        dp::emit_context const ctx{outputStream};
+        dp::emit_context ctx{outputStream};
         REQUIRE(dp::emit_integer(ctx, sample.value));
 
         CHECK(std::ranges::equal(outputStream.written(),
@@ -76,7 +76,7 @@ TEMPLATE_TEST_CASE("positive integers emit correctly",
         std::vector<std::byte> encodingBuffer(dp::detail::var_uint_max_size);
         dp::memory_output_stream outputStream(encodingBuffer);
 
-        dp::emit_context const ctx{outputStream};
+        dp::emit_context ctx{outputStream};
         REQUIRE(dp::emit_integer(ctx, sample.value));
 
         CHECK(std::ranges::equal(outputStream.written(),
@@ -100,7 +100,7 @@ TEMPLATE_TEST_CASE("negative integers emit correctly",
         std::vector<std::byte> encodingBuffer(sample.encoded_length);
         dp::memory_output_stream outputStream(encodingBuffer);
 
-        dp::emit_context const ctx{outputStream};
+        dp::emit_context ctx{outputStream};
         REQUIRE(dp::emit_integer(ctx, sample.value));
 
         CHECK(std::ranges::equal(outputStream.written(),
@@ -112,7 +112,7 @@ TEMPLATE_TEST_CASE("negative integers emit correctly",
         std::vector<std::byte> encodingBuffer(dp::detail::var_uint_max_size);
         dp::memory_output_stream outputStream(encodingBuffer);
 
-        dp::emit_context const ctx{outputStream};
+        dp::emit_context ctx{outputStream};
         REQUIRE(dp::emit_integer(ctx, sample.value));
 
         CHECK(std::ranges::equal(outputStream.written(),
@@ -127,7 +127,7 @@ TEST_CASE("finite prefixes are emitted correctly")
 
     std::vector<std::byte> encodingBuffer(sample.encoded_length);
     dp::memory_output_stream outputStream(encodingBuffer);
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
 
     SECTION("for binary")
     {
@@ -169,7 +169,7 @@ TEST_CASE("emit_binary writes a short blob")
 
     std::vector<std::byte> buffer(sample.encoded_length);
     dp::memory_output_stream outputStream(buffer);
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
 
     REQUIRE(emit_binary(
             ctx,
@@ -190,7 +190,7 @@ TEST_CASE("emit_u8string writes a short string")
 
     std::vector<std::byte> buffer(sample.encoded_length);
     dp::memory_output_stream outputStream(buffer);
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
 
     SECTION("for char8_t const *")
     {
@@ -215,7 +215,7 @@ TEST_CASE("indefinite prefixes are emitted correctly")
 {
     std::vector<std::byte> encodingBuffer(1U);
     dp::memory_output_stream outputStream(encodingBuffer);
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
 
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::byte expected{0x1f};
@@ -252,7 +252,7 @@ TEST_CASE("float single emits correctly")
     std::vector<std::byte> encodingBuffer(sample.encoded_length);
     dp::memory_output_stream outputStream(encodingBuffer);
 
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
     REQUIRE(emit_float_single(ctx, sample.value));
 
     CHECK(std::ranges::equal(outputStream.written(), sample.encoded_bytes()));
@@ -266,7 +266,7 @@ TEST_CASE("float double emits correctly")
     std::vector<std::byte> encodingBuffer(sample.encoded_length);
     dp::memory_output_stream outputStream(encodingBuffer);
 
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
     REQUIRE(emit_float_double(ctx, sample.value));
 
     CHECK(std::ranges::equal(outputStream.written(), sample.encoded_bytes()));
@@ -277,7 +277,7 @@ TEST_CASE("null emits correctly")
     std::vector<std::byte> encodingBuffer(1U);
     dp::memory_output_stream outputStream(encodingBuffer);
 
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
     REQUIRE(emit_null(ctx));
 
     REQUIRE(outputStream.written().size() == 1U);
@@ -290,7 +290,7 @@ TEST_CASE("undefined emits correctly")
     std::vector<std::byte> encodingBuffer(1U);
     dp::memory_output_stream outputStream(encodingBuffer);
 
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
     REQUIRE(emit_undefined(ctx));
 
     REQUIRE(outputStream.written().size() == 1U);
@@ -303,7 +303,7 @@ TEST_CASE("break emits correctly")
     std::vector<std::byte> encodingBuffer(1U);
     dp::memory_output_stream outputStream(encodingBuffer);
 
-    dp::emit_context const ctx{outputStream};
+    dp::emit_context ctx{outputStream};
     REQUIRE(emit_break(ctx));
 
     REQUIRE(outputStream.written().size() == 1U);

--- a/src/dplx/dp/items/emit_ranges.hpp
+++ b/src/dplx/dp/items/emit_ranges.hpp
@@ -26,7 +26,7 @@ namespace detail
 template <typename Fn, typename R>
 concept subitem_emitlet
         = requires(Fn &&encodeFn,
-                   emit_context const ctx,
+                   emit_context ctx,
                    std::ranges::range_reference_t<R const> v)
         {
             { static_cast<Fn &&>(encodeFn)(ctx, v) }
@@ -35,7 +35,7 @@ concept subitem_emitlet
 // clang-format on
 
 template <typename R, typename EncodeElementFn>
-inline auto emit_array_like(emit_context const &ctx,
+inline auto emit_array_like(emit_context &ctx,
                             R const &vs,
                             type_code type,
                             EncodeElementFn &&encodeElement) noexcept
@@ -75,7 +75,7 @@ inline auto emit_array_like(emit_context const &ctx,
     }
 }
 template <typename R, typename EncodeElementFn>
-inline auto emit_indefinite_array_like(emit_context const &ctx,
+inline auto emit_indefinite_array_like(emit_context &ctx,
                                        R const &vs,
                                        type_code type,
                                        EncodeElementFn &&encodeElement) noexcept
@@ -95,7 +95,7 @@ inline auto emit_indefinite_array_like(emit_context const &ctx,
 template <std::ranges::input_range R, typename EncodeElementFn>
     requires(std::ranges::forward_range<R> || std::ranges::sized_range<R>)
          && detail::subitem_emitlet<std::remove_cvref_t<EncodeElementFn>, R>
-            inline auto emit_array(emit_context const &ctx,
+            inline auto emit_array(emit_context &ctx,
                                    R const &vs,
                                    EncodeElementFn &&encodeElement) noexcept
             -> result<void>
@@ -106,7 +106,7 @@ template <std::ranges::input_range R, typename EncodeElementFn>
 }
 template <std::ranges::input_range R, typename EncodeElementFn>
     requires detail::subitem_emitlet<std::remove_cvref_t<EncodeElementFn>, R>
-inline auto emit_array_indefinite(emit_context const &ctx,
+inline auto emit_array_indefinite(emit_context &ctx,
                                   R const &vs,
                                   EncodeElementFn &&encodeElement) noexcept
         -> result<void>
@@ -119,7 +119,7 @@ inline auto emit_array_indefinite(emit_context const &ctx,
 template <std::ranges::input_range R, typename EncodeElementFn>
     requires(std::ranges::forward_range<R> || std::ranges::sized_range<R>)
          && detail::subitem_emitlet<std::remove_cvref_t<EncodeElementFn>, R>
-            inline auto emit_map(emit_context const &ctx,
+            inline auto emit_map(emit_context &ctx,
                                  R const &vs,
                                  EncodeElementFn &&encodeElement) noexcept
             -> result<void>
@@ -130,7 +130,7 @@ template <std::ranges::input_range R, typename EncodeElementFn>
 }
 template <std::ranges::input_range R, typename EncodeElementFn>
     requires detail::subitem_emitlet<std::remove_cvref_t<EncodeElementFn>, R>
-inline auto emit_map_indefinite(emit_context const &ctx,
+inline auto emit_map_indefinite(emit_context &ctx,
                                 R const &vs,
                                 EncodeElementFn &&encodeElement) noexcept
         -> result<void>

--- a/src/dplx/dp/items/emit_ranges.test.cpp
+++ b/src/dplx/dp/items/emit_ranges.test.cpp
@@ -122,7 +122,7 @@ TEST_CASE("emit_map loops over a range of encodable pairs and emits them")
     INFO(sample);
 
     simple_test_emit_context ctx(sample.encoded.size());
-    auto encodePair = [](dp::emit_context const &lctx,
+    auto encodePair = [](dp::emit_context &lctx,
                          std::pair<int, int> const &pair) -> dp::result<void>
     {
         DPLX_TRY(dp::encode(lctx, pair.first));
@@ -146,7 +146,7 @@ TEST_CASE("emit_map loops over a range of encodable pairs and emits them")
     {
         CHECK(dp::item_size_of_map(
                       ctx.as_emit_context(), sample.value,
-                      [](dp::emit_context const &lctx,
+                      [](dp::emit_context &lctx,
                          std::pair<int, int> const &pair) -> std::uint64_t
                       {
                           return dp::encoded_size_of(lctx, pair.first)
@@ -166,7 +166,7 @@ TEST_CASE("emit_map_indefinite loops over an input range of encodable pairs "
     INFO(sample);
 
     simple_test_emit_context ctx(sample.encoded.size());
-    auto encodePair = [](dp::emit_context const &lctx,
+    auto encodePair = [](dp::emit_context &lctx,
                          std::pair<int, int> const &pair) -> dp::result<void>
     {
         DPLX_TRY(dp::encode(lctx, pair.first));
@@ -185,7 +185,7 @@ TEST_CASE("emit_map_indefinite loops over an input range of encodable pairs "
     {
         CHECK(dp::item_size_of_map_indefinite(
                       ctx.as_emit_context(), dp::indefinite_range(sample.value),
-                      [](dp::emit_context const &lctx,
+                      [](dp::emit_context &lctx,
                          std::pair<int, int> const &pair) -> std::uint64_t
                       {
                           return dp::encoded_size_of(lctx, pair.first)

--- a/src/dplx/dp/items/item_size_of_core.hpp
+++ b/src/dplx/dp/items/item_size_of_core.hpp
@@ -17,7 +17,7 @@ namespace dplx::dp
 {
 
 template <detail::encodable_int T>
-[[nodiscard]] constexpr auto item_size_of_integer(emit_context const &,
+[[nodiscard]] constexpr auto item_size_of_integer(emit_context &,
                                                   T value) noexcept
         -> std::uint64_t
 {
@@ -42,7 +42,7 @@ template <detail::encodable_int T>
 }
 
 template <detail::encodable_int T>
-[[nodiscard]] constexpr auto item_size_of_binary(emit_context const &,
+[[nodiscard]] constexpr auto item_size_of_binary(emit_context &,
                                                  T byteSize) noexcept
         -> std::uint64_t
 {
@@ -53,8 +53,8 @@ template <detail::encodable_int T>
          + static_cast<std::uint64_t>(byteSize);
 }
 template <detail::encodable_int T>
-[[nodiscard]] constexpr auto
-item_size_of_binary_indefinite(emit_context const &, T byteSize) noexcept
+[[nodiscard]] constexpr auto item_size_of_binary_indefinite(emit_context &,
+                                                            T byteSize) noexcept
         -> std::uint64_t
 {
     assert(byteSize >= 0);
@@ -62,7 +62,7 @@ item_size_of_binary_indefinite(emit_context const &, T byteSize) noexcept
 }
 
 template <detail::encodable_int T>
-[[nodiscard]] constexpr auto item_size_of_u8string(emit_context const &,
+[[nodiscard]] constexpr auto item_size_of_u8string(emit_context &,
                                                    T numCodeUnits) noexcept
         -> std::uint64_t
 {
@@ -74,42 +74,41 @@ template <detail::encodable_int T>
 }
 template <detail::encodable_int T>
 [[nodiscard]] constexpr auto
-item_size_of_u8string_indefinite(emit_context const &, T numCodeUnits) noexcept
+item_size_of_u8string_indefinite(emit_context &, T numCodeUnits) noexcept
         -> std::uint64_t
 {
     assert(numCodeUnits >= 0);
     return 1U + static_cast<std::uint64_t>(numCodeUnits) + 1U;
 }
 
-[[nodiscard]] constexpr auto item_size_of_boolean(emit_context const &,
-                                                  bool) noexcept
+[[nodiscard]] constexpr auto item_size_of_boolean(emit_context &, bool) noexcept
         -> std::uint64_t
 {
     return 1U;
 }
 
-[[nodiscard]] constexpr auto item_size_of_float_single(emit_context const &,
+[[nodiscard]] constexpr auto item_size_of_float_single(emit_context &,
                                                        float) noexcept
         -> std::uint64_t
 {
     return 5U; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 }
 
-[[nodiscard]] constexpr auto item_size_of_float_double(emit_context const &,
+[[nodiscard]] constexpr auto item_size_of_float_double(emit_context &,
                                                        double) noexcept
         -> std::uint64_t
 {
     return 9U; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 }
 
-[[nodiscard]] constexpr auto item_size_of_null(emit_context const &) noexcept
+[[nodiscard]] constexpr auto item_size_of_null(emit_context &) noexcept
         -> std::uint64_t
 {
     return 1U;
 }
 
-[[nodiscard]] constexpr auto
-item_size_of_undefined(emit_context const &) noexcept -> std::uint64_t
+[[nodiscard]] constexpr auto item_size_of_undefined(emit_context &) noexcept
+        -> std::uint64_t
 {
     return 1U;
 }

--- a/src/dplx/dp/items/item_size_of_core.test.cpp
+++ b/src/dplx/dp/items/item_size_of_core.test.cpp
@@ -37,7 +37,7 @@ TEMPLATE_TEST_CASE("positive integers' size is correctly estimated",
     INFO(sample);
 
     dp::void_stream testStream;
-    dp::emit_context const ctx{testStream};
+    dp::emit_context ctx{testStream};
 
     CHECK(dp::item_size_of_integer(ctx, sample.value) == sample.encoded_length);
 }
@@ -54,7 +54,7 @@ TEMPLATE_TEST_CASE("negative integers' size is correctly estimated",
     INFO(sample);
 
     dp::void_stream testStream;
-    dp::emit_context const ctx{testStream};
+    dp::emit_context ctx{testStream};
 
     CHECK(dp::item_size_of_integer(ctx, sample.value) == sample.encoded_length);
 }
@@ -65,7 +65,7 @@ TEST_CASE("binary item size is correctly estimated")
             = GENERATE(borrowed_range(binary_samples));
 
     dp::void_stream testStream;
-    dp::emit_context const ctx{testStream};
+    dp::emit_context ctx{testStream};
 
     CHECK(dp::item_size_of_binary(ctx, sample.value) == sample.encoded_length);
     CHECK(dp::item_size_of_binary_indefinite(ctx, sample.value)
@@ -78,7 +78,7 @@ TEST_CASE("u8string item size is correctly estimated")
             = GENERATE(borrowed_range(u8string_samples));
 
     dp::void_stream testStream;
-    dp::emit_context const ctx{testStream};
+    dp::emit_context ctx{testStream};
 
     CHECK(dp::item_size_of_u8string(ctx, sample.value.size())
           == sample.encoded_length);

--- a/src/dplx/dp/items/item_size_of_ranges.hpp
+++ b/src/dplx/dp/items/item_size_of_ranges.hpp
@@ -25,7 +25,7 @@ namespace detail
 template <typename Fn, typename R>
 concept subitem_size_of
     = requires(Fn &&sizeOfFn,
-               emit_context const ctx,
+               emit_context ctx,
                std::ranges::range_reference_t<R const> v)
     {
         { static_cast<Fn &&>(sizeOfFn)(ctx, v) }
@@ -34,7 +34,7 @@ concept subitem_size_of
 // clang-format on
 
 template <typename R, typename SizeOfElementFn>
-inline auto item_size_of_array_like(emit_context const &ctx,
+inline auto item_size_of_array_like(emit_context &ctx,
                                     R const &vs,
                                     SizeOfElementFn &&sizeOfElement) noexcept
         -> std::uint64_t
@@ -72,7 +72,7 @@ inline auto item_size_of_array_like(emit_context const &ctx,
 }
 template <typename R, typename SizeOfElementFn>
 inline auto
-item_size_of_indefinite_array_like(emit_context const &ctx,
+item_size_of_indefinite_array_like(emit_context &ctx,
                                    R const &vs,
                                    SizeOfElementFn &&sizeOfElement) noexcept
         -> std::uint64_t
@@ -93,7 +93,7 @@ template <std::ranges::input_range R, typename SizeOfElementFn>
     requires(std::ranges::forward_range<R> || std::ranges::sized_range<R>)
          && detail::subitem_size_of<std::remove_cvref_t<SizeOfElementFn>, R>
             inline auto item_size_of_array(
-                    emit_context const &ctx,
+                    emit_context &ctx,
                     R const &vs,
                     SizeOfElementFn &&sizeOfElement) noexcept -> std::uint64_t
 {
@@ -103,7 +103,7 @@ template <std::ranges::input_range R, typename SizeOfElementFn>
 template <std::ranges::input_range R, typename SizeOfElementFn>
     requires detail::subitem_size_of<std::remove_cvref_t<SizeOfElementFn>, R>
 inline auto
-item_size_of_array_indefinite(emit_context const &ctx,
+item_size_of_array_indefinite(emit_context &ctx,
                               R const &vs,
                               SizeOfElementFn &&sizeOfElement) noexcept
         -> std::uint64_t
@@ -117,7 +117,7 @@ template <std::ranges::input_range R, typename SizeOfElementFn>
          && detail::subitem_size_of<std::remove_cvref_t<SizeOfElementFn>, R>
             // clang-format on
             inline auto item_size_of_map(
-                    emit_context const &ctx,
+                    emit_context &ctx,
                     R const &vs,
                     SizeOfElementFn &&sizeOfElement) noexcept -> std::uint64_t
 {
@@ -127,7 +127,7 @@ template <std::ranges::input_range R, typename SizeOfElementFn>
 template <std::ranges::input_range R, typename SizeOfElementFn>
     requires detail::subitem_size_of<std::remove_cvref_t<SizeOfElementFn>, R>
 inline auto
-item_size_of_map_indefinite(emit_context const &ctx,
+item_size_of_map_indefinite(emit_context &ctx,
                             R const &vs,
                             SizeOfElementFn &&sizeOfElement) noexcept
         -> std::uint64_t


### PR DESCRIPTION
### Purpose
In order to allow storing state in the emit_context in a future API extension it needs to be mutable. Note that since it stores the output_buffer by reference, there are no concerns w.r.t. codecs replacing the current output_buffer.

### Additional explanatory comments
This was an early design mishap in #4 which I forgot to rectify before merging.