### PR TITLE
Treat types derived from `*_buffer` as streams

### DIFF
--- a/src/dplx/dp/api.hpp
+++ b/src/dplx/dp/api.hpp
@@ -136,11 +136,10 @@ inline constexpr struct decode_fn final
         auto &&buffer = get_input_buffer(static_cast<InStream &&>(inStream));
         parse_context ctx{static_cast<input_buffer &>(buffer)};
         result<T> decodeRx = (*this)(as_value<T>, ctx);
-        if (decodeRx.has_failure())
+        if (decodeRx.has_value())
         {
-            return static_cast<decltype(decodeRx) &&>(decodeRx).as_failure();
+            DPLX_TRY(static_cast<input_buffer &>(buffer).sync_input());
         }
-        DPLX_TRY(static_cast<input_buffer &>(buffer).sync_input());
         return decodeRx;
     }
     template <typename T>
@@ -188,9 +187,9 @@ inline constexpr struct decode_fn final
         {
             result<T> rx(oc::success());
             if (auto parseRx = codec<T>::decode(ctx, rx.assume_value());
-                parseRx.has_failure()) [[unlikely]]
+                parseRx.has_error()) [[unlikely]]
             {
-                rx = static_cast<decltype(parseRx) &&>(parseRx).as_failure();
+                rx = static_cast<decltype(parseRx) &&>(parseRx).assume_error();
             }
             return rx;
         }

--- a/src/dplx/dp/cpos/stream.hpp
+++ b/src/dplx/dp/cpos/stream.hpp
@@ -26,18 +26,25 @@ inline constexpr struct get_output_buffer_fn
             && std::convertible_to<
                     std::add_lvalue_reference_t<cncr::tag_invoke_result_t<get_output_buffer_fn, OutStream &&>>,
                     output_buffer &>
-    //clang-format on
-    inline auto operator()(OutStream &&outStream) const noexcept
-            -> cncr::tag_invoke_result_t<get_output_buffer_fn, OutStream &&>
+                 // clang-format on
+                 inline auto operator()(OutStream &&outStream) const noexcept
+                 -> cncr::tag_invoke_result_t<get_output_buffer_fn,
+                                              OutStream &&>
     {
         return cncr::tag_invoke(*this, static_cast<OutStream &&>(outStream));
+    }
+
+    inline auto operator()(output_buffer &outStream) const noexcept
+            -> output_buffer &
+    {
+        return outStream;
     }
 
 } get_output_buffer{};
 
 inline constexpr struct get_input_buffer_fn
 {
-    template <typename InStream> 
+    template <typename InStream>
     // clang-format off
         requires cncr::nothrow_tag_invocable<get_input_buffer_fn, InStream &&>
             && std::is_base_of_v<input_buffer,
@@ -45,12 +52,27 @@ inline constexpr struct get_input_buffer_fn
             && std::convertible_to<
                     std::add_lvalue_reference_t<cncr::tag_invoke_result_t<get_input_buffer_fn, InStream &&>>,
                     input_buffer &>
-    //clang-format on
-                inline auto
-            operator()(InStream &&inStream) const noexcept
-            -> cncr::tag_invoke_result_t<get_input_buffer_fn, InStream &&>
+                 // clang-format on
+                 inline auto operator()(InStream &&inStream) const noexcept
+                 -> cncr::tag_invoke_result_t<get_input_buffer_fn, InStream &&>
     {
         return cncr::tag_invoke(*this, static_cast<InStream &&>(inStream));
+    }
+
+    inline auto operator()(input_buffer &inStream) const noexcept
+            -> input_buffer &
+    {
+        return inStream;
+    }
+    template <typename T>
+        requires(!cncr::tag_invocable<get_input_buffer_fn, T &&>)
+             && std::is_rvalue_reference_v<T &&>
+             && (!std::is_const_v<std::remove_reference_t<T>>)
+             && std::movable<std::remove_reference_t<T>>
+             && std::derived_from<std::remove_reference_t<T>, input_buffer>
+                inline auto operator()(T &&inStream) const noexcept -> T
+    {
+        return static_cast<T &&>(inStream);
     }
 
 } get_input_buffer{};

--- a/src/dplx/dp/cpos/stream.test.cpp
+++ b/src/dplx/dp/cpos/stream.test.cpp
@@ -9,11 +9,92 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <dplx/dp/api.hpp>
+#include <dplx/dp/codecs/core.hpp>
+#include <dplx/dp/streams/input_buffer.hpp>
+#include <dplx/dp/streams/output_buffer.hpp>
+
 #include "test_utils.hpp"
 
 namespace dp_tests
 {
 
-// TODO: Add tests for stream CPOs
+namespace
+{
+
+class movable_stream final
+    : public dp::input_buffer
+    , public dp::output_buffer
+{
+public:
+    ~movable_stream() noexcept = default;
+    movable_stream() noexcept = default;
+
+    movable_stream(movable_stream const &) noexcept = delete;
+    auto operator=(movable_stream const &) noexcept
+            -> movable_stream & = delete;
+
+    movable_stream(movable_stream &&) noexcept
+        : input_buffer()
+        , output_buffer()
+    {
+    }
+    auto operator=(movable_stream &&) noexcept -> movable_stream &
+    {
+        return *this;
+    }
+
+private:
+    auto do_require_input(input_buffer::size_type) noexcept
+            -> dp::result<void> override
+    {
+        return dp::errc::bad;
+    }
+    auto do_discard_input(input_buffer::size_type) noexcept
+            -> dp::result<void> override
+    {
+        return dp::errc::bad;
+    }
+    auto do_bulk_read(std::byte *, std::size_t) noexcept
+            -> dp::result<void> override
+    {
+        return dp::errc::bad;
+    }
+
+    auto do_grow(output_buffer::size_type) noexcept -> dp::result<void> override
+    {
+        return dp::errc::bad;
+    }
+    auto do_bulk_write(std::byte const *, std::size_t) noexcept
+            -> dp::result<void> override
+    {
+        return dp::errc::bad;
+    }
+};
+
+} // namespace
+
+static_assert(dp::input_stream<movable_stream>);
+static_assert(dp::input_stream<movable_stream &>);
+static_assert(!dp::output_stream<movable_stream>);
+static_assert(dp::output_stream<movable_stream &>);
+
+TEST_CASE("movable_stream can be passed as lvalue to encode")
+{
+    movable_stream stream{};
+    CHECK(dp::encode(stream, dp::null_value).error() == dp::errc::bad);
+}
+
+TEST_CASE("movable_stream can be passed as lvalue to decode")
+{
+    movable_stream stream{};
+    CHECK(dp::decode(dp::as_value<int>, stream).error()
+          == dp::errc::end_of_stream);
+}
+TEST_CASE("movable_stream can be passed as rvalue to decode")
+{
+    CHECK(dp::decode(dp::as_value<int>, movable_stream{}).error()
+          == dp::errc::end_of_stream);
+}
 
 } // namespace dp_tests


### PR DESCRIPTION
### Purpose

Types derived from `*_buffer` were accepted by `(de|en)code` APIs, but did not satisfy the `*_stream` concepts. This generalizes the usage of these types outside of our public APIs.