### PR TITLE
feat: Add state API to `parse_context`

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: lukka/run-vcpkg@v10
         with:
           vcpkgDirectory: ${{ github.workspace }}/build/vcpkg
-          vcpkgGitCommitId: 71d3fa60b67540e9bf5fde2bf2188f579ff09433
+          vcpkgGitCommitId: 1271068e139c1fc30bae405c0bca0e379e155bd2
           prependedCacheKey: compiler=${{ matrix.compiler }}
           #appendedCacheKey: r00
 
@@ -100,7 +100,7 @@ jobs:
         uses: lukka/run-vcpkg@v10
         with:
           vcpkgDirectory: ${{ github.workspace }}/../vcpkg
-          vcpkgGitCommitId: 71d3fa60b67540e9bf5fde2bf2188f579ff09433
+          vcpkgGitCommitId: 1271068e139c1fc30bae405c0bca0e379e155bd2
           prependedCacheKey: compiler=clang-15
           #appendedCacheKey: r00
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         /Zc:__cplusplus # correctly define the __cplusplus macro
     )
 endif()
+if (WIN32)
+    target_compile_definitions(compiler_settings INTERFACE
+        -D_ENABLE_EXTENDED_ALIGNED_STORAGE=1
+    )
+endif()
 
 
 ########################################################################

--- a/sources.cmake
+++ b/sources.cmake
@@ -31,6 +31,7 @@ dplx_target_sources(deeppack
         dp/layout_descriptor
         dp/macros
         dp/object_def
+        dp/state
         dp/tuple_def
 
         dp/codecs/auto_enum

--- a/src/dp_tests/test_input_stream.hpp
+++ b/src/dp_tests/test_input_stream.hpp
@@ -88,22 +88,25 @@ private:
     }
 };
 
-class simple_test_parse_context final : private dp::parse_context
+class simple_test_parse_context final
 {
+    dp::parse_context ctx;
+
 public:
+    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
     simple_test_input_stream stream;
 
     explicit simple_test_parse_context(
             std::span<std::byte const> const readBuffer,
             bool const initiallyEmpty = false)
-        : parse_context{stream}
+        : ctx{stream}
         , stream(readBuffer, initiallyEmpty)
     {
     }
 
     auto as_parse_context() noexcept -> dp::parse_context &
     {
-        return *this;
+        return ctx;
     }
 };
 

--- a/src/dp_tests/test_output_stream.hpp
+++ b/src/dp_tests/test_output_stream.hpp
@@ -250,22 +250,25 @@ private:
     }
 };
 
-class test_emit_context final : private dp::emit_context
+class test_emit_context final
 {
+    dp::emit_context ctx;
+
 public:
+    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
     test_output_stream stream;
 
     explicit test_emit_context(
             std::initializer_list<std::size_t> const gatherBufferSizes,
             bool const initiallyEmpty = false)
-        : emit_context{stream}
+        : ctx{stream}
         , stream(gatherBufferSizes, initiallyEmpty)
     {
     }
 
     auto as_emit_context() noexcept -> dp::emit_context &
     {
-        return *this;
+        return ctx;
     }
 };
 

--- a/src/dplx/dp/items/parse_context.hpp
+++ b/src/dplx/dp/items/parse_context.hpp
@@ -7,7 +7,11 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory_resource>
+
 #include <dplx/dp/fwd.hpp>
+#include <dplx/dp/state.hpp>
 
 namespace dplx::dp
 {
@@ -15,6 +19,24 @@ namespace dplx::dp
 struct parse_context
 {
     input_buffer &in;
+    state_store states;
+    link_store links;
+
+    explicit parse_context(
+            input_buffer &inStreamBuffer,
+            std::pmr::polymorphic_allocator<std::byte> const &allocator
+            = std::pmr::polymorphic_allocator<std::byte>{})
+        : in(inStreamBuffer)
+        , states(allocator)
+        , links(allocator)
+    {
+    }
+
+    [[nodiscard]] auto get_allocator() const noexcept
+            -> std::pmr::polymorphic_allocator<std::byte>
+    {
+        return states.get_allocator();
+    }
 };
 
 } // namespace dplx::dp

--- a/src/dplx/dp/state.hpp
+++ b/src/dplx/dp/state.hpp
@@ -1,0 +1,463 @@
+
+// Copyright 2023 Henrik Steffen Gaßmann
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <memory>
+#include <memory_resource>
+#include <utility>
+
+#include <parallel_hashmap/phmap.h>
+
+#include <dplx/cncr/utils.hpp>
+#include <dplx/cncr/uuid.hpp>
+
+#include <dplx/dp/fwd.hpp>
+
+namespace dplx::dp::detail
+{
+
+template <typename T, std::size_t PadSize>
+struct erasure_pad
+{
+    T value;
+    std::byte padding[PadSize];
+};
+template <typename T>
+struct erasure_pad<T, 0U>
+{
+    T value;
+};
+
+template <typename To, typename From>
+    requires(sizeof(From) < sizeof(To))
+constexpr auto erasure_cast(From const &value) noexcept -> To
+{
+    return std::bit_cast<To>(
+            erasure_pad<From, sizeof(To) - sizeof(From)>{value, {}});
+}
+template <typename To, typename From>
+    requires(sizeof(From) == sizeof(To))
+constexpr auto erasure_cast(From const &value) noexcept -> To
+{
+    return std::bit_cast<To>(value);
+}
+
+} // namespace dplx::dp::detail
+
+namespace dplx::dp::detail
+{
+
+template <typename Allocator = std::pmr::polymorphic_allocator<std::byte>>
+class unique_erased_state_ptr;
+
+template <typename T, typename Allocator, typename... Args>
+constexpr auto allocate_state(Allocator const &alloc, Args &&...args)
+        -> unique_erased_state_ptr<Allocator>;
+
+template <typename Allocator>
+class unique_erased_state_ptr
+{
+    template <typename T, typename Alloc, typename... Args>
+    friend constexpr auto allocate_state(Alloc const &alloc, Args &&...args)
+            -> unique_erased_state_ptr<Alloc>;
+
+    using delete_fn = void (*)(void *obj) noexcept;
+
+    void *mObj{};
+    delete_fn mDelete{};
+
+    template <typename StateT>
+    struct container
+    {
+        DPLX_ATTR_NO_UNIQUE_ADDRESS Allocator allocator;
+        StateT state;
+
+        using allocator_type = Allocator;
+
+        constexpr container() = default;
+
+        container(container const &) = delete;
+        auto operator=(container const &) -> container & = delete;
+
+        container(container &&) = delete;
+        auto operator=(container &&) -> container & = delete;
+
+        template <typename Arg, typename... Args>
+            requires(!std::is_same_v<std::remove_cvref_t<Arg>,
+                                     std::allocator_arg_t>)
+        constexpr container(Arg &&arg, Args &&...args)
+            : allocator()
+            , state(static_cast<Arg &&>(arg), static_cast<Args &&>(args)...)
+        {
+        }
+        template <typename... Args>
+        constexpr container(std::allocator_arg_t,
+                            Allocator const &alloc,
+                            Args &&...args)
+            : allocator(alloc)
+            , state(std::make_obj_using_allocator<StateT, Allocator>(
+                      alloc, static_cast<Args &&>(args)...))
+        {
+        }
+    };
+
+public:
+    constexpr ~unique_erased_state_ptr() noexcept
+    {
+        if (mObj != nullptr && mDelete != nullptr)
+        {
+            mDelete(mObj);
+        }
+    }
+    constexpr unique_erased_state_ptr() noexcept = default;
+
+    constexpr unique_erased_state_ptr(unique_erased_state_ptr &&other) noexcept
+        : mObj(std::exchange(other.mObj, nullptr))
+        , mDelete(std::exchange(other.mDelete, nullptr))
+    {
+    }
+    constexpr auto operator=(unique_erased_state_ptr &&other) noexcept
+            -> unique_erased_state_ptr &
+    {
+        mObj = std::exchange(other.mObj, nullptr);
+        mDelete = std::exchange(other.mDelete, nullptr);
+
+        return *this;
+    }
+
+private:
+    template <typename StateT>
+    constexpr explicit unique_erased_state_ptr(container<StateT> *obj)
+        : mObj(static_cast<void *>(obj))
+        , mDelete(&deleter<StateT>)
+    {
+    }
+
+public:
+    template <typename StateT>
+    [[nodiscard]] auto get() const noexcept -> StateT *
+    {
+        return mObj == nullptr ? nullptr
+                               : &static_cast<container<StateT> *>(mObj)->state;
+    }
+
+private:
+    template <typename T>
+    static void deleter(void *obj) noexcept
+    {
+        using allocator_type = typename std::allocator_traits<Allocator>::
+                template rebind_alloc<typename unique_erased_state_ptr<
+                        Allocator>::template container<T>>;
+        using allocator_traits = typename std::allocator_traits<allocator_type>;
+
+        auto *wrapped = static_cast<container<T> *>(obj);
+        allocator_type allocator(wrapped->allocator);
+
+        allocator_traits::destroy(allocator, wrapped);
+        allocator_traits::deallocate(allocator, wrapped, 1U);
+    }
+};
+
+template <typename T, typename Allocator, typename... Args>
+constexpr auto allocate_state(Allocator const &alloc, Args &&...args)
+        -> unique_erased_state_ptr<Allocator>
+{
+    using allocator_type =
+            typename std::allocator_traits<Allocator>::template rebind_alloc<
+                    typename unique_erased_state_ptr<
+                            Allocator>::template container<T>>;
+    using allocator_traits = typename std::allocator_traits<allocator_type>;
+
+    allocator_type allocator(alloc);
+    typename allocator_traits::pointer obj
+            = allocator_traits::allocate(allocator, 1U);
+    try
+    {
+        allocator_traits::construct(allocator, obj,
+                                    static_cast<Args &&>(args)...);
+        return unique_erased_state_ptr<Allocator>(obj);
+    }
+    catch (...)
+    {
+        allocator_traits::deallocate(allocator, obj, 1U);
+        throw;
+    }
+}
+
+} // namespace dplx::dp::detail
+
+namespace dplx::dp::detail
+{
+
+template <typename Key, typename T>
+using flat_hash_map = phmap::flat_hash_map<
+        Key,
+        T,
+        std::hash<Key>,
+        std::equal_to<>,
+        std::pmr::polymorphic_allocator<std::pair<const Key, T>>>;
+
+}
+
+namespace dplx::dp
+{
+
+class state_base
+{
+public:
+    virtual ~state_base() noexcept = default;
+
+protected:
+    constexpr state_base() noexcept = default;
+
+    constexpr state_base(state_base const &) noexcept = default;
+    constexpr auto operator=(state_base const &) noexcept
+            -> state_base & = default;
+
+    constexpr state_base(state_base &&) noexcept = default;
+    constexpr auto operator=(state_base &&) noexcept -> state_base & = default;
+};
+
+template <typename StateT>
+struct state_key
+{
+    cncr::uuid const value{};
+
+    using state_type = StateT;
+};
+
+class state_store
+{
+public:
+    using allocator_type = std::pmr::polymorphic_allocator<std::byte>;
+
+private:
+    using impl_type = detail::flat_hash_map<
+            cncr::uuid,
+            detail::unique_erased_state_ptr<allocator_type>>;
+    impl_type mImpl{};
+
+public:
+    state_store() = default;
+
+    state_store(allocator_type const &alloc)
+        : mImpl(alloc)
+    {
+    }
+
+    [[nodiscard]] auto get_allocator() const noexcept -> allocator_type
+    {
+        return mImpl.get_allocator();
+    }
+    void reserve(typename impl_type::size_type slots)
+    {
+        mImpl.reserve(slots);
+    }
+
+    [[nodiscard]] auto empty() const noexcept -> bool
+    {
+        return mImpl.empty();
+    }
+    template <typename StateT>
+    [[nodiscard]] auto try_access(state_key<StateT> const &key) const noexcept
+            -> StateT *
+    {
+        if (auto it = mImpl.find(key.value); it != mImpl.end())
+        {
+            return it->second.template get<StateT>();
+        }
+        return nullptr;
+    }
+
+    template <typename StateT, typename... Args>
+    auto emplace(state_key<StateT> const &key, Args &&...args)
+            -> std::pair<StateT *, bool>
+    {
+        auto const h = mImpl.hash(key.value);
+        if (auto it = mImpl.find(key.value, h); it != mImpl.end())
+        {
+            // this way, we don't need to allocate if key already has a value
+            return {it->second.template get<StateT>(), false};
+        }
+        auto [it, emplaced] = mImpl.emplace_with_hash(
+                h, key.value,
+                detail::allocate_state<StateT, allocator_type>(
+                        mImpl.get_allocator(), static_cast<Args &&>(args)...));
+        return {it->second.template get<StateT>(), true};
+    }
+    template <typename StateT>
+    auto erase(state_key<StateT> const &key) noexcept -> std::size_t
+    {
+        return mImpl.erase(key.value);
+    }
+    auto erase(cncr::uuid key) noexcept -> std::size_t
+    {
+        return mImpl.erase(key);
+    }
+    void clear() noexcept
+    {
+        mImpl.clear();
+    }
+};
+
+template <typename StateT>
+    requires std::default_initializable<StateT>
+class [[nodiscard]] scoped_state
+{
+    state_key<StateT> mKey;
+    state_store &mStore;
+    bool owned;
+
+public:
+    ~scoped_state() noexcept
+    {
+        if (owned)
+        {
+            mStore.erase(mKey.value);
+        }
+    }
+    explicit scoped_state(state_store &store, state_key<StateT> const &key)
+        : mKey(key)
+        , mStore(store)
+        , owned(false)
+    {
+        assert(!key.value.is_nil());
+        owned = store.emplace(key).second;
+    }
+
+    [[nodiscard]] auto get() const noexcept -> StateT *
+    {
+        return mStore.try_access(mKey);
+    }
+};
+
+template <typename T>
+concept state_link = std::regular<T> && std::is_trivial_v<T>
+                  && (sizeof(T) <= sizeof(cncr::uuid));
+
+template <state_link T>
+struct [[nodiscard]] state_link_key
+{
+    cncr::uuid const value{};
+
+    using link_type = T;
+};
+
+class link_store
+{
+public:
+    using allocator_type = std::pmr::polymorphic_allocator<std::byte>;
+
+private:
+    using erased_type
+            = cncr::blob<std::byte, sizeof(cncr::uuid), alignof(cncr::uuid)>;
+    using impl_type = detail::flat_hash_map<cncr::uuid, erased_type>;
+    impl_type mImpl{};
+
+public:
+    link_store() = default;
+
+    link_store(allocator_type const &alloc)
+        : mImpl(alloc)
+    {
+    }
+
+    [[nodiscard]] auto get_allocator() const noexcept -> allocator_type
+    {
+        return mImpl.get_allocator();
+    }
+    void reserve(typename impl_type::size_type slots)
+    {
+        mImpl.reserve(slots);
+    }
+
+    [[nodiscard]] auto empty() const noexcept -> bool
+    {
+        return mImpl.empty();
+    }
+    template <state_link T>
+    [[nodiscard]] auto try_access(state_link_key<T> const &key) const noexcept
+            -> T
+    {
+        if (auto it = mImpl.find(key.value); it != mImpl.end())
+        {
+            return std::bit_cast<detail::erasure_pad<T, sizeof(erased_type)
+                                                                - sizeof(T)>>(
+                           it->second)
+                    .value;
+        }
+        return T{};
+    }
+
+    void clear() noexcept
+    {
+        mImpl.clear();
+    }
+    template <state_link T>
+    auto replace(state_link_key<T> const &key, T value) -> T
+    {
+        auto const h = mImpl.hash(key.value);
+        auto it = mImpl.find(key.value, h);
+        if (it == mImpl.end())
+        {
+            if (value != T{})
+            {
+                mImpl.emplace_with_hash(
+                        h, key.value,
+                        detail::erasure_cast<erased_type, T>(value));
+            }
+            return T{};
+        }
+
+        auto previousValue = std::bit_cast<detail::erasure_pad<
+                T, sizeof(erased_type) - sizeof(T)>>(it->second)
+                                     .value;
+        if (value == T{})
+        {
+            mImpl.erase(it);
+        }
+        else
+        {
+            it->second = detail::erasure_cast<erased_type, T>(value);
+        }
+        return previousValue;
+    }
+};
+
+template <state_link T>
+class [[nodiscard]] scoped_link
+{
+    state_link_key<T> mKey;
+    T mPreviousValue;
+    link_store &mStore;
+
+public:
+    ~scoped_link() noexcept
+    {
+        mStore.replace(mKey, mPreviousValue);
+    }
+    explicit scoped_link(link_store &store,
+                         state_link_key<T> const &key,
+                         T value)
+        : mKey(key)
+        , mPreviousValue(store.replace(key, value))
+        , mStore(store)
+    {
+    }
+
+    [[nodiscard]] auto get() const noexcept -> T
+    {
+        return mStore.try_access(mKey);
+    }
+    [[nodiscard]] auto shadowed_value() const noexcept -> T
+    {
+        return mPreviousValue;
+    }
+};
+
+} // namespace dplx::dp

--- a/src/dplx/dp/state.test.cpp
+++ b/src/dplx/dp/state.test.cpp
@@ -1,0 +1,86 @@
+
+// Copyright 2023 Henrik Steffen Gaßmann
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/dp/state.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "test_utils.hpp"
+
+namespace dp_tests
+{
+
+using namespace cncr::uuid_literals;
+
+TEST_CASE("state_map is default constructible")
+{
+    dp::state_store states;
+    CHECK(states.empty());
+}
+
+TEST_CASE("can insert a simple state into state_map")
+{
+    constexpr dp::state_key<int> k{"fdd790a7-c618-4e58-b412-8042b42bd9bb"_uuid};
+    dp::state_store states;
+
+    auto const value = 4;
+    auto [state, inserted] = states.emplace(k, value);
+    CHECK(inserted);
+    CHECK(*state == 4);
+
+    auto *accessed = states.try_access(k);
+    CHECK(state == accessed);
+}
+
+TEST_CASE("scoped_state manages a state lifetime")
+{
+    constexpr dp::state_key<int> k{"fdd790a7-c618-4e58-b412-8042b42bd9bb"_uuid};
+    dp::state_store states;
+
+    CHECK(states.try_access(k) == nullptr);
+    {
+        dp::scoped_state stateScope(states, k);
+        REQUIRE(stateScope.get() != nullptr);
+        CHECK(*stateScope.get() == int{});
+    }
+    CHECK(states.try_access(k) == nullptr);
+}
+
+TEST_CASE("link_map is default constructible")
+{
+    dp::link_store links;
+    CHECK(links.empty());
+}
+
+TEST_CASE("can insert a simple link into link_map")
+{
+    constexpr dp::state_link_key<int> k{
+            "fdd790a7-c618-4e58-b412-8042b42bd9bb"_uuid};
+    dp::link_store links;
+
+    auto const value = 4;
+    CHECK(links.replace(k, value) == int{});
+
+    CHECK(value == links.try_access(k));
+}
+
+TEST_CASE("scoped_link manages a link lifetime")
+{
+    constexpr dp::state_link_key<int> k{
+            "fdd790a7-c618-4e58-b412-8042b42bd9bb"_uuid};
+    dp::link_store links;
+
+    CHECK(links.try_access(k) == int{});
+    {
+        auto const value = 4;
+        dp::scoped_link linkScope(links, k, value);
+        CHECK(links.try_access(k) == value);
+    }
+    CHECK(links.try_access(k) == int{});
+}
+
+} // namespace dp_tests

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,16 +2,14 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
     "default-registry": {
         "kind": "builtin",
-        "baseline": "71d3fa60b67540e9bf5fde2bf2188f579ff09433"
+        "baseline": "1271068e139c1fc30bae405c0bca0e379e155bd2"
     },
     "registries": [
         {
             "kind": "git",
             "repository": "https://github.com/deeplex/vcpkg-registry",
-            "baseline": "e0379d3342d009a2ca0b713af9ced5df6e155ada",
-            "packages": [
-                "concrete"
-            ]
+            "baseline": "92fdbb474589c5b134d1dd2083df3f258c56c639",
+            "packages": ["concrete"]
         }
     ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,7 @@
         "concrete",
         "fmt",
         "outcome",
+        "parallel-hashmap",
         "status-code"
     ],
     "features": {


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
<!--
Explain the **motivation** for making this change. What existing problem does
the pull request solve? This could be a short summary of the motivating issue.


You may remove this if you're fixing a typo.
-->

Resolves #13 <!-- associate the motivating issue -->


### Solution Sketch
<!--
Outline the design decisions leading to this very change set.
You may also remove this if you're fixing a typo 😉
-->
This will cause some bifurcation of `encoded_size_of()` and `encode` due to missing constexpr support in virtually all high quality `unordered_map` implementations. The current plan is to create a seperate `size_of_context` which won't contain any APIs for the time being.


