### PR TITLE
refactor: Update concrete and unify outcome usage

### DIFF
--- a/src/dp_tests/simple_encodable.hpp
+++ b/src/dp_tests/simple_encodable.hpp
@@ -42,6 +42,6 @@ public:
         DPLX_TRY(ctx.out.ensure_size(1U));
         *ctx.out.data() = static_cast<std::byte>(obj.value);
         ctx.out.commit_written(1U);
-        return oc::success();
+        return outcome::success();
     }
 };

--- a/src/dp_tests/test_input_stream.hpp
+++ b/src/dp_tests/test_input_stream.hpp
@@ -50,7 +50,7 @@ public:
 
 private:
     auto do_require_input(size_type requiredSize) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         if (!std::exchange(mInitiallyEmpty, false)
             || requiredSize > mReadBuffer.size())
@@ -60,8 +60,7 @@ private:
         reset(mReadBuffer.data(), mReadBuffer.size(), mReadBuffer.size());
         return dp::oc::success();
     }
-    auto do_discard_input(size_type amount) noexcept
-            -> dp::result<void> override
+    auto do_discard_input(size_type amount) noexcept -> result<void> override
     {
         if (!std::exchange(mInitiallyEmpty, false)
             || amount > mReadBuffer.size())
@@ -73,7 +72,7 @@ private:
         return dp::oc::success();
     }
     auto do_bulk_read(std::byte *dest, std::size_t size) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         if (!std::exchange(mInitiallyEmpty, false) || size > mReadBuffer.size())
         {

--- a/src/dp_tests/test_input_stream.hpp
+++ b/src/dp_tests/test_input_stream.hpp
@@ -58,7 +58,7 @@ private:
             return dp::errc::end_of_stream;
         }
         reset(mReadBuffer.data(), mReadBuffer.size(), mReadBuffer.size());
-        return dp::oc::success();
+        return outcome::success();
     }
     auto do_discard_input(size_type amount) noexcept -> result<void> override
     {
@@ -69,7 +69,7 @@ private:
         }
         auto const remaining = mReadBuffer.subspan(amount);
         reset(remaining.data(), remaining.size(), remaining.size());
-        return dp::oc::success();
+        return outcome::success();
     }
     auto do_bulk_read(std::byte *dest, std::size_t size) noexcept
             -> result<void> override
@@ -83,7 +83,7 @@ private:
 
         auto const remaining = mReadBuffer.subspan(size);
         reset(remaining.data(), remaining.size(), remaining.size());
-        return dp::oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dp_tests/test_output_stream.hpp
+++ b/src/dp_tests/test_output_stream.hpp
@@ -62,7 +62,7 @@ private:
             return dp::errc::end_of_stream;
         }
         reset(mBuffer.data(), mBuffer.size());
-        return dp::oc::success();
+        return outcome::success();
     }
 
     auto do_bulk_write(std::byte const *const src,
@@ -79,7 +79,7 @@ private:
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             reset(mBuffer.data() + srcSize, mBuffer.size() - srcSize);
         }
-        return dp::oc::success();
+        return outcome::success();
     }
 };
 
@@ -197,7 +197,7 @@ private:
             else
             {
                 reset(currentBuffer.data(), currentBuffer.size());
-                return dp::oc::success();
+                return outcome::success();
             }
         }
         reset();
@@ -237,7 +237,7 @@ private:
         {
             return dp::errc::end_of_stream;
         }
-        return dp::oc::success();
+        return outcome::success();
     }
 
     void finalize_current_buffer() noexcept

--- a/src/dp_tests/test_output_stream.hpp
+++ b/src/dp_tests/test_output_stream.hpp
@@ -54,8 +54,7 @@ public:
     }
 
 private:
-    auto do_grow(size_type const requested) noexcept
-            -> dp::result<void> override
+    auto do_grow(size_type const requested) noexcept -> result<void> override
     {
         if (!std::exchange(mInitiallyEmpty, false)
             || requested > mBuffer.size())
@@ -68,7 +67,7 @@ private:
 
     auto do_bulk_write(std::byte const *const src,
                        std::size_t const srcSize) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         if (!std::exchange(mInitiallyEmpty, false) || srcSize > mBuffer.size())
         {
@@ -182,7 +181,7 @@ private:
     }
 
     auto do_grow(size_type const requestedSize) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         if (!std::exchange(mInitiallyEmpty, false))
         {
@@ -205,7 +204,7 @@ private:
         return dp::errc::end_of_stream;
     }
     auto do_bulk_write(std::byte const *src, std::size_t size) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         if (!std::exchange(mInitiallyEmpty, false))
         {

--- a/src/dp_tests/test_utils.hpp
+++ b/src/dp_tests/test_utils.hpp
@@ -36,7 +36,7 @@ namespace detail
 template <typename T>
 concept is_fmt_formattable = fmt::is_formattable<T>::value;
 
-inline auto format_error(dp::system_error::status_code<void> const &esc)
+inline auto format_error(system_error::status_code<void> const &esc)
         -> std::string
 {
     auto const domainNameRef = esc.domain().name();
@@ -53,9 +53,9 @@ inline auto format_error(dp::system_error::status_code<void> const &esc)
 
 template <typename T>
     requires dp_tests::detail::is_fmt_formattable<T const &>
-struct Catch::StringMaker<dplx::dp::result<T>>
+struct Catch::StringMaker<dplx::result<T>>
 {
-    static auto convert(dplx::dp::result<T> const &rx) -> std::string
+    static auto convert(dplx::result<T> const &rx) -> std::string
     {
         if (rx.has_value())
         {
@@ -67,9 +67,9 @@ struct Catch::StringMaker<dplx::dp::result<T>>
 };
 
 template <>
-struct Catch::StringMaker<dplx::dp::result<void>>
+struct Catch::StringMaker<dplx::result<void>>
 {
-    static auto convert(dplx::dp::result<void> const &rx) -> std::string
+    static auto convert(dplx::result<void> const &rx) -> std::string
     {
         using namespace std::string_literals;
         if (rx.has_value())

--- a/src/dplx/dp/api.hpp
+++ b/src/dplx/dp/api.hpp
@@ -167,7 +167,7 @@ inline constexpr struct decode_fn final
         // clang-format off
         else if constexpr (requires {
                               { codec<T>::decode(ctx) } noexcept
-                                  -> detail::tryable_result<T>;
+                                  -> cncr::tryable_result<T>;
                            })
         // clang-format on
         {

--- a/src/dplx/dp/api.hpp
+++ b/src/dplx/dp/api.hpp
@@ -172,20 +172,20 @@ inline constexpr struct decode_fn final
         // clang-format on
         {
             if (auto parseRx = codec<T>::decode(ctx);
-                oc::try_operation_has_value(parseRx)) [[likely]]
+                outcome::try_operation_has_value(parseRx)) [[likely]]
             {
-                return oc::try_operation_extract_value(
+                return outcome::try_operation_extract_value(
                         static_cast<decltype(parseRx) &&>(parseRx));
             }
             else [[unlikely]]
             {
-                return oc::try_operation_return_as(
+                return outcome::try_operation_return_as(
                         static_cast<decltype(parseRx) &&>(parseRx));
             }
         }
         else
         {
-            result<T> rx(oc::success());
+            result<T> rx(outcome::success());
             if (auto parseRx = codec<T>::decode(ctx, rx.assume_value());
                 parseRx.has_error()) [[unlikely]]
             {

--- a/src/dplx/dp/codecs/auto_enum.hpp
+++ b/src/dplx/dp/codecs/auto_enum.hpp
@@ -39,7 +39,7 @@ public:
             return static_cast<result<void> &&>(parseRx).as_failure();
         }
         value = static_cast<T>(underlyingValue);
-        return oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dplx/dp/codecs/auto_tuple.test.cpp
+++ b/src/dplx/dp/codecs/auto_tuple.test.cpp
@@ -96,7 +96,7 @@ TEST_CASE("encode tuple with layout descriptor 1")
     {
         simple_test_parse_context ctx(sample.encoded_bytes());
 
-        dp::result<dp::tuple_head_info> headParseRx
+        result<dp::tuple_head_info> headParseRx
                 = dp::decode_tuple_head(ctx.as_parse_context());
         REQUIRE(headParseRx);
         auto const &head = headParseRx.assume_value();
@@ -143,7 +143,7 @@ TEST_CASE("encode tuple with layout descriptor 2")
     {
         simple_test_parse_context ctx(sample.encoded_bytes());
 
-        dp::result<dp::tuple_head_info> headParseRx
+        result<dp::tuple_head_info> headParseRx
                 = dp::decode_tuple_head(ctx.as_parse_context());
         REQUIRE(headParseRx);
         auto const &head = headParseRx.assume_value();
@@ -190,7 +190,7 @@ TEST_CASE("encode tuple with layout descriptor 3")
     {
         simple_test_parse_context ctx(sample.encoded_bytes());
 
-        dp::result<dp::tuple_head_info> headParseRx
+        result<dp::tuple_head_info> headParseRx
                 = dp::decode_tuple_head(ctx.as_parse_context());
         REQUIRE(headParseRx);
         auto const &head = headParseRx.assume_value();
@@ -232,7 +232,7 @@ TEST_CASE("encode tuple with layout descriptor 4")
     {
         simple_test_parse_context ctx(sample.encoded_bytes());
 
-        dp::result<dp::tuple_head_info> headParseRx = dp::decode_tuple_head(
+        result<dp::tuple_head_info> headParseRx = dp::decode_tuple_head(
                 ctx.as_parse_context(), std::true_type{});
         REQUIRE(headParseRx);
         auto const &head = headParseRx.assume_value();
@@ -274,7 +274,7 @@ TEST_CASE("encode tuple with layout descriptor 5")
     {
         simple_test_parse_context ctx(sample.encoded_bytes());
 
-        dp::result<dp::tuple_head_info> headParseRx
+        result<dp::tuple_head_info> headParseRx
                 = dp::decode_tuple_head(ctx.as_parse_context());
         REQUIRE(headParseRx);
         auto const &head = headParseRx.assume_value();

--- a/src/dplx/dp/codecs/fixed_u8string.cpp
+++ b/src/dplx/dp/codecs/fixed_u8string.cpp
@@ -41,7 +41,7 @@ auto decode_fixed_u8string(parse_context &ctx, char8_t *out, unsigned &outlen)
     DPLX_TRY(auto len, dp::parse_text_finite(ctx, buffer, maxlen));
 
     outlen = static_cast<unsigned>(len);
-    return oc::success();
+    return outcome::success();
 }
 
 } // namespace dplx::dp::detail

--- a/src/dplx/dp/codecs/std-container.hpp
+++ b/src/dplx/dp/codecs/std-container.hpp
@@ -339,7 +339,7 @@ public:
     {
         vs.clear();
         DPLX_TRY(dp::parse_map(ctx, vs, decode_pair));
-        return oc::success();
+        return outcome::success();
     }
 
 private:
@@ -528,7 +528,7 @@ private:
         auto const &[key, mapped] = value;
         DPLX_TRY(encode(ctx, key));
         DPLX_TRY(encode(ctx, mapped));
-        return oc::success();
+        return outcome::success();
     }
     static auto decode_pair(parse_context &ctx,
                             std::span<T> const value,
@@ -538,7 +538,7 @@ private:
         auto &[key, mapped] = value[i];
         DPLX_TRY(decode(ctx, key));
         DPLX_TRY(decode(ctx, mapped));
-        return oc::success();
+        return outcome::success();
     }
 };
 */

--- a/src/dplx/dp/codecs/std-string.cpp
+++ b/src/dplx/dp/codecs/std-string.cpp
@@ -45,7 +45,7 @@ auto codec<std::u8string>::decode(parse_context &ctx,
                                   std::u8string &value) noexcept -> result<void>
 {
     DPLX_TRY(dp::parse_text<std::u8string>(ctx, value));
-    return oc::success();
+    return outcome::success();
 }
 
 auto codec<std::string_view>::size_of(emit_context &ctx,
@@ -78,7 +78,7 @@ auto codec<std::string>::decode(parse_context &ctx, std::string &value) noexcept
         -> result<void>
 {
     DPLX_TRY(dp::parse_text<std::string>(ctx, value));
-    return oc::success();
+    return outcome::success();
 }
 
 } // namespace dplx::dp

--- a/src/dplx/dp/codecs/system_error2.test.cpp
+++ b/src/dplx/dp/codecs/system_error2.test.cpp
@@ -20,7 +20,7 @@
 namespace dp_tests
 {
 
-using string_ref = dp::system_error::status_code_domain::string_ref;
+using string_ref = system_error::status_code_domain::string_ref;
 
 TEST_CASE("system_error2::status_code_domain::string_ref should be encodable")
 {

--- a/src/dplx/dp/codecs/uuid.cpp
+++ b/src/dplx/dp/codecs/uuid.cpp
@@ -24,7 +24,7 @@ auto dplx::dp::codec<cncr::uuid>::decode(parse_context &ctx,
     DPLX_TRY(ctx.in.bulk_read(static_cast<std::byte *>(raw.values), stateSize));
 
     value = cncr::uuid(raw.values);
-    return oc::success();
+    return outcome::success();
 }
 
 auto codec<cncr::uuid>::encode(emit_context &ctx,

--- a/src/dplx/dp/concepts.hpp
+++ b/src/dplx/dp/concepts.hpp
@@ -28,7 +28,7 @@ concept encodable
         requires !std::is_reference_v<T>;
         requires !std::is_pointer_v<T>;
         { codec<std::remove_const_t<T>>::encode(ctx, t) } noexcept
-            -> oc::concepts::basic_result;
+            -> outcome::concepts::basic_result;
         { codec<std::remove_const_t<T>>::size_of(ctx, t) } noexcept
             -> std::same_as<std::uint64_t>;
     };
@@ -43,7 +43,7 @@ concept decodable
         requires !std::is_pointer_v<T>;
         requires !std::is_const_v<T>;
         { codec<T>::decode(ctx, t) } noexcept
-            -> oc::concepts::basic_result;
+            -> outcome::concepts::basic_result;
     };
 // clang-format on
 
@@ -56,7 +56,7 @@ concept value_decodable
         || requires(parse_context ctx)
            {
                { codec<T>::decode(ctx) } noexcept
-                   -> detail::tryable_result<T>;
+                   -> cncr::tryable_result<T>;
            });
 // clang-format on
 

--- a/src/dplx/dp/cpos/container.hpp
+++ b/src/dplx/dp/cpos/container.hpp
@@ -54,7 +54,7 @@ inline constexpr struct container_reserve_fn
         try
         {
             container.reserve(reservationSize);
-            return oc::success();
+            return outcome::success();
         }
         catch (std::bad_alloc const &)
         {
@@ -102,7 +102,7 @@ inline constexpr struct container_resize_fn
         try
         {
             container.resize(newSize);
-            return oc::success();
+            return outcome::success();
         }
         catch (std::bad_alloc const &)
         {

--- a/src/dplx/dp/cpos/container.std.hpp
+++ b/src/dplx/dp/cpos/container.std.hpp
@@ -22,7 +22,7 @@ inline auto tag_invoke(container_reserve_fn,
 {
     if (size <= c.size())
     {
-        return oc::success();
+        return outcome::success();
     }
     return errc::not_enough_memory;
 }
@@ -33,7 +33,7 @@ inline auto tag_invoke(container_resize_fn,
 {
     if (size <= c.size())
     {
-        return oc::success();
+        return outcome::success();
     }
     return errc::not_enough_memory;
 }

--- a/src/dplx/dp/cpos/stream.test.cpp
+++ b/src/dplx/dp/cpos/stream.test.cpp
@@ -46,27 +46,27 @@ public:
 
 private:
     auto do_require_input(input_buffer::size_type) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         return dp::errc::bad;
     }
     auto do_discard_input(input_buffer::size_type) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         return dp::errc::bad;
     }
     auto do_bulk_read(std::byte *, std::size_t) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         return dp::errc::bad;
     }
 
-    auto do_grow(output_buffer::size_type) noexcept -> dp::result<void> override
+    auto do_grow(output_buffer::size_type) noexcept -> result<void> override
     {
         return dp::errc::bad;
     }
     auto do_bulk_write(std::byte const *, std::size_t) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         return dp::errc::bad;
     }

--- a/src/dplx/dp/disappointment.hpp
+++ b/src/dplx/dp/disappointment.hpp
@@ -11,11 +11,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <outcome/experimental/status_result.hpp>
-#include <outcome/try.hpp>
-#include <status-code/system_code.hpp>
-
 #include <dplx/cncr/data_defined_status_domain.hpp>
+#include <dplx/cncr/disappointment.hpp>
 
 namespace dplx::dp
 {
@@ -118,7 +115,7 @@ namespace dplx::dp
 {
 
 template <typename R>
-using result = oc::experimental::status_result<R>;
+using result = dplx::result<R>;
 
 }
 

--- a/src/dplx/dp/items/emit_core.hpp
+++ b/src/dplx/dp/items/emit_core.hpp
@@ -63,7 +63,7 @@ inline auto store_var_uint_eos(output_buffer &out,
     // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
 
     out.commit_written(byteSize);
-    return oc::success();
+    return outcome::success();
 }
 
 template <typename T>
@@ -112,7 +112,7 @@ inline auto store_var_uint(output_buffer &out,
     detail::store(dest + 1, encoded);
 
     out.commit_written(byteSize);
-    return oc::success();
+    return outcome::success();
 }
 
 inline auto store_inline_value(output_buffer &out,
@@ -130,7 +130,7 @@ inline auto store_inline_value(output_buffer &out,
             = static_cast<std::byte>(value | static_cast<unsigned>(category));
 
     out.commit_written(encodedSize);
-    return oc::success();
+    return outcome::success();
 }
 
 } // namespace dplx::dp::detail
@@ -283,7 +283,7 @@ inline auto emit_float_single(emit_context &ctx, float const value) noexcept
     detail::store(dest + 1, value);
 
     ctx.out.commit_written(encodedSize);
-    return oc::success();
+    return outcome::success();
 }
 
 inline auto emit_float_double(emit_context &ctx, double const value) noexcept
@@ -301,7 +301,7 @@ inline auto emit_float_double(emit_context &ctx, double const value) noexcept
     detail::store(dest + 1, value);
 
     ctx.out.commit_written(encodedSize);
-    return oc::success();
+    return outcome::success();
 }
 
 inline auto emit_null(emit_context &ctx) noexcept -> result<void>

--- a/src/dplx/dp/items/emit_ranges.hpp
+++ b/src/dplx/dp/items/emit_ranges.hpp
@@ -30,7 +30,7 @@ concept subitem_emitlet
                    std::ranges::range_reference_t<R const> v)
         {
             { static_cast<Fn &&>(encodeFn)(ctx, v) }
-                -> tryable;
+                -> cncr::tryable;
         };
 // clang-format on
 

--- a/src/dplx/dp/items/emit_ranges.hpp
+++ b/src/dplx/dp/items/emit_ranges.hpp
@@ -54,7 +54,7 @@ inline auto emit_array_like(emit_context &ctx,
         {
             DPLX_TRY(static_cast<EncodeElementFn &&>(encodeElement)(ctx, v));
         }
-        return oc::success();
+        return outcome::success();
     }
     else
     {
@@ -71,7 +71,7 @@ inline auto emit_array_like(emit_context &ctx,
         {
             DPLX_TRY(static_cast<EncodeElementFn &&>(encodeElement)(ctx, *it));
         }
-        return oc::success();
+        return outcome::success();
     }
 }
 template <typename R, typename EncodeElementFn>

--- a/src/dplx/dp/items/emit_ranges.test.cpp
+++ b/src/dplx/dp/items/emit_ranges.test.cpp
@@ -123,7 +123,7 @@ TEST_CASE("emit_map loops over a range of encodable pairs and emits them")
 
     simple_test_emit_context ctx(sample.encoded.size());
     auto encodePair = [](dp::emit_context &lctx,
-                         std::pair<int, int> const &pair) -> dp::result<void>
+                         std::pair<int, int> const &pair) -> result<void>
     {
         DPLX_TRY(dp::encode(lctx, pair.first));
         return dp::encode(lctx, pair.second);
@@ -167,7 +167,7 @@ TEST_CASE("emit_map_indefinite loops over an input range of encodable pairs "
 
     simple_test_emit_context ctx(sample.encoded.size());
     auto encodePair = [](dp::emit_context &lctx,
-                         std::pair<int, int> const &pair) -> dp::result<void>
+                         std::pair<int, int> const &pair) -> result<void>
     {
         DPLX_TRY(dp::encode(lctx, pair.first));
         return dp::encode(lctx, pair.second);

--- a/src/dplx/dp/items/parse_core.hpp
+++ b/src/dplx/dp/items/parse_core.hpp
@@ -267,7 +267,7 @@ inline auto expect_item_head(parse_context &ctx,
             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             if (value == 0x1fU)
             {
-                return oc::success();
+                return outcome::success();
             }
             // unwanted special break.
             return errc::item_type_mismatch;
@@ -278,7 +278,7 @@ inline auto expect_item_head(parse_context &ctx,
     {
         return errc::item_value_out_of_range;
     }
-    return oc::success();
+    return outcome::success();
 }
 
 template <detail::encodable_int T>
@@ -316,7 +316,7 @@ inline auto parse_integer(parse_context &ctx, T &outValue) noexcept
     auto const xorpad = static_cast<std::uint64_t>(signExtended);
 
     outValue = static_cast<T>(head.value ^ xorpad);
-    return oc::success();
+    return outcome::success();
 }
 
 template <detail::encodable_int T>
@@ -343,7 +343,7 @@ inline auto parse_integer(parse_context &ctx,
         return errc::item_value_out_of_range;
     }
     outValue = static_cast<T>(head.value);
-    return oc::success();
+    return outcome::success();
 }
 
 inline auto parse_boolean(parse_context &ctx, bool &outValue) noexcept
@@ -365,7 +365,7 @@ inline auto parse_boolean(parse_context &ctx, bool &outValue) noexcept
     }
     outValue = rolled == 1U;
     ctx.in.discard_buffered(1U);
-    return oc::success();
+    return outcome::success();
 }
 
 namespace detail

--- a/src/dplx/dp/items/parse_core.test.cpp
+++ b/src/dplx/dp/items/parse_core.test.cpp
@@ -26,7 +26,7 @@ using enum dp::type_code;
 
 constexpr item_sample_ct<dp::item_head> parse_samples[] = {
   // clang-format off
-              
+
     // Appendix A.Examples
     {
         {posint, {}, 1, 0},
@@ -76,7 +76,7 @@ constexpr item_sample_ct<dp::item_head> parse_samples[] = {
     // posint boundaries
     {
         {posint, {}, 1, 0x17},
-        1, {0x17}, 
+        1, {0x17},
     },
     {
         {posint, {}, 2, 0x18},
@@ -315,7 +315,7 @@ TEMPLATE_TEST_CASE("parse_integer parses positive integers",
         simple_test_parse_context ctx(sample.encoded_bytes());
 
         TestType value;
-        dp::result<void> rx
+        result<void> rx
                 = dp::parse_integer<TestType>(ctx.as_parse_context(), value);
         if (std::in_range<TestType>(sample.value))
         {
@@ -334,7 +334,7 @@ TEMPLATE_TEST_CASE("parse_integer parses positive integers",
         simple_test_parse_context ctx(as_bytes(std::span(sample.encoded)));
 
         TestType value;
-        dp::result<void> rx
+        result<void> rx
                 = dp::parse_integer<TestType>(ctx.as_parse_context(), value);
         if (std::in_range<TestType>(sample.value))
         {
@@ -367,7 +367,7 @@ TEMPLATE_TEST_CASE("parse_integer parses negative integers correctly",
         simple_test_parse_context ctx(sample.encoded_bytes());
 
         TestType value;
-        dp::result<void> rx
+        result<void> rx
                 = dp::parse_integer<TestType>(ctx.as_parse_context(), value);
         if (std::in_range<TestType>(sample.value))
         {
@@ -386,7 +386,7 @@ TEMPLATE_TEST_CASE("parse_integer parses negative integers correctly",
         simple_test_parse_context ctx(as_bytes(std::span(sample.encoded)));
 
         TestType value;
-        dp::result<void> rx
+        result<void> rx
                 = dp::parse_integer<TestType>(ctx.as_parse_context(), value);
         if (std::in_range<TestType>(sample.value))
         {

--- a/src/dplx/dp/items/parse_ranges.hpp
+++ b/src/dplx/dp/items/parse_ranges.hpp
@@ -204,7 +204,7 @@ concept subitem_parslet
     = requires(Fn &&decodeFn, parse_context &ctx, Container &dest, std::size_t const i)
     {
         { static_cast<Fn &&>(decodeFn)(ctx, dest, i) } noexcept
-            -> tryable;
+            -> cncr::tryable;
     };
 // clang-format on
 

--- a/src/dplx/dp/items/parse_ranges.test.cpp
+++ b/src/dplx/dp/items/parse_ranges.test.cpp
@@ -152,7 +152,7 @@ TEST_CASE("parse_array parses a finite array of integers into a vector")
     simple_test_parse_context ctx(sample.encoded_bytes());
     std::vector<int> value;
     auto decodeElement = [](dp::parse_context &lctx, std::vector<int> &dest,
-                            std::size_t const) noexcept -> dp::result<void>
+                            std::size_t const) noexcept -> result<void>
     {
         return dp::decode(lctx, dest.emplace_back());
     };
@@ -189,7 +189,7 @@ TEST_CASE("parse_array parses an indefinite array of integers into a vector")
     simple_test_parse_context ctx(sample.encoded_bytes());
     std::vector<int> value;
     auto decodeElement = [](dp::parse_context &lctx, std::vector<int> &dest,
-                            std::size_t const) noexcept -> dp::result<void>
+                            std::size_t const) noexcept -> result<void>
     {
         return dp::decode(lctx, dest.emplace_back());
     };
@@ -224,7 +224,7 @@ TEST_CASE("parse_map parses a finite map of integers into a vector of pairs")
     std::vector<std::pair<int, int>> value;
     auto decodePair = [](dp::parse_context &lctx,
                          std::vector<std::pair<int, int>> &dest,
-                         std::size_t const) noexcept -> dp::result<void>
+                         std::size_t const) noexcept -> result<void>
     {
         auto &pair = dest.emplace_back();
         DPLX_TRY(dp::decode(lctx, pair.first));
@@ -265,7 +265,7 @@ TEST_CASE(
     std::vector<std::pair<int, int>> value;
     auto decodePair = [](dp::parse_context &lctx,
                          std::vector<std::pair<int, int>> &dest,
-                         std::size_t const) noexcept -> dp::result<void>
+                         std::size_t const) noexcept -> result<void>
     {
         auto &pair = dest.emplace_back();
         DPLX_TRY(dp::decode(lctx, pair.first));

--- a/src/dplx/dp/items/skip_item.cpp
+++ b/src/dplx/dp/items/skip_item.cpp
@@ -54,7 +54,7 @@ static auto skip_binary_or_text(parse_context &ctx, item_head const &item)
 
         DPLX_TRY(ctx.in.discard_input(chunkInfo.value));
     }
-    return oc::success();
+    return outcome::success();
 }
 
 } // namespace detail
@@ -201,7 +201,7 @@ auto skip_item(parse_context &ctx) noexcept -> result<void>
 
     } while (!stack.empty());
 
-    return oc::success();
+    return outcome::success();
 }
 
 } // namespace dplx::dp

--- a/src/dplx/dp/legacy/chunked_input_stream.hpp
+++ b/src/dplx/dp/legacy/chunked_input_stream.hpp
@@ -134,7 +134,7 @@ private:
             {
                 return require_input(requiredSize);
             }
-            return oc::success();
+            return outcome::success();
         }
 
         if (mBufferStart < 0)
@@ -150,7 +150,7 @@ private:
 
             if (requiredSize <= size())
             {
-                return oc::success();
+                return outcome::success();
             }
             if (size() == small_buffer_size)
             {
@@ -172,7 +172,7 @@ private:
             {
                 return require_input(requiredSize);
             }
-            return oc::success();
+            return outcome::success();
         }
 
         if (requiredSize > small_buffer_size)
@@ -185,7 +185,7 @@ private:
 
         if (requiredSize <= size())
         {
-            return oc::success();
+            return outcome::success();
         }
 
         // mReadArea has been completely drained and copied to mSmallBuffer
@@ -218,7 +218,7 @@ private:
         }
         reset(mReadArea.remaining_begin(), mReadArea.remaining_size(),
               input_size());
-        return oc::success();
+        return outcome::success();
     }
 
     auto do_bulk_read(std::byte *dest, std::size_t readAmount) noexcept
@@ -248,7 +248,7 @@ private:
         }
         reset(mReadArea.remaining_begin(), mReadArea.remaining_size(),
               input_size());
-        return oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dplx/dp/legacy/chunked_input_stream.test.cpp
+++ b/src/dplx/dp/legacy/chunked_input_stream.test.cpp
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    auto acquire_next_chunk_impl(std::uint64_t) -> dp::result<dp::memory_view>
+    auto acquire_next_chunk_impl(std::uint64_t) -> result<dp::memory_view>
     {
         if (mNext >= mChunks.size())
         {

--- a/src/dplx/dp/legacy/chunked_output_stream.hpp
+++ b/src/dplx/dp/legacy/chunked_output_stream.hpp
@@ -65,7 +65,7 @@ private:
 
         mRemaining -= mCurrentChunk.size();
 
-        return oc::success();
+        return outcome::success();
     }
 #if defined(DPLX_COMP_GNUC_AVAILABLE) && !defined(DPLX_COMP_CLANG_AVAILABLE)
 #pragma GCC diagnostic pop
@@ -79,7 +79,7 @@ private:
             {
                 DPLX_TRY(acquire_next_chunk());
                 reset(mCurrentChunk.data(), mCurrentChunk.size());
-                return oc::success();
+                return outcome::success();
             }
             if (requestedSize > small_buffer_size)
             {
@@ -87,7 +87,7 @@ private:
             }
             mDecomissionThreshold = static_cast<std::int8_t>(size());
             reset(static_cast<std::byte *>(mSmallBuffer), small_buffer_size);
-            return oc::success();
+            return outcome::success();
         }
 
         auto const chunkPart = mCurrentChunk.last(
@@ -105,7 +105,7 @@ private:
 
             reset(static_cast<std::byte *>(mSmallBuffer), small_buffer_size);
             mDecomissionThreshold -= static_cast<std::int8_t>(consumedSize);
-            return oc::success();
+            return outcome::success();
         }
 
         std::memcpy(chunkPart.data(), static_cast<std::byte *>(mSmallBuffer),
@@ -174,7 +174,7 @@ private:
             }
         } while (writeAmount != 0);
         reset(mCurrentChunk.data(), mCurrentChunk.size());
-        return oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dplx/dp/legacy/chunked_output_stream.test.cpp
+++ b/src/dplx/dp/legacy/chunked_output_stream.test.cpp
@@ -54,7 +54,7 @@ public:
     }
 
 private:
-    auto acquire_next_chunk_impl() -> dp::result<std::span<std::byte>>
+    auto acquire_next_chunk_impl() -> result<std::span<std::byte>>
     {
         if (mNext >= mChunks.size())
         {

--- a/src/dplx/dp/legacy/memory_input_stream.hpp
+++ b/src/dplx/dp/legacy/memory_input_stream.hpp
@@ -63,7 +63,7 @@ private:
         mImpl.move_consumer(
                 static_cast<typename basic_memory_buffer<T>::difference_type>(
                         writtenSize));
-        return oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dplx/dp/legacy/memory_output_stream.hpp
+++ b/src/dplx/dp/legacy/memory_output_stream.hpp
@@ -50,7 +50,7 @@ private:
         auto const writtenSize = data() - mImpl.remaining_begin();
         mImpl.move_consumer(
                 static_cast<memory_buffer::difference_type>(writtenSize));
-        return oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dplx/dp/object_def.hpp
+++ b/src/dplx/dp/object_def.hpp
@@ -174,7 +174,7 @@ struct object_def
     template <typename Fn>
     static inline auto mp_for_dots(Fn &&fn) -> result<void>
     {
-        result<void> rx = oc::success();
+        result<void> rx = outcome::success();
 
         [[maybe_unused]] bool failed
                 = (...

--- a/src/dplx/dp/streams/input_buffer.hpp
+++ b/src/dplx/dp/streams/input_buffer.hpp
@@ -132,7 +132,7 @@ public:
 
     auto require_input(size_type const requiredSize) noexcept -> result<void>
     {
-        result<void> rx = oc::success();
+        result<void> rx = outcome::success();
         if (requiredSize > mInputSize)
         {
             rx = errc::end_of_stream;
@@ -157,7 +157,7 @@ public:
         if (amount <= mInputBufferSize)
         {
             discard_buffered(amount);
-            return oc::success();
+            return outcome::success();
         }
         if (amount > mInputSize)
         {
@@ -178,7 +178,7 @@ public:
     {
         if (amount == 0U) [[unlikely]]
         {
-            return oc::success();
+            return outcome::success();
         }
         if (amount > mInputSize)
         {
@@ -198,7 +198,7 @@ public:
         }
         if (amount == 0U)
         {
-            return oc::success();
+            return outcome::success();
         }
         return do_bulk_read(dest, amount);
     }
@@ -257,7 +257,7 @@ private:
             = 0;
     virtual auto do_sync_input() noexcept -> result<void>
     {
-        return oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dplx/dp/streams/input_buffer.test.cpp
+++ b/src/dplx/dp/streams/input_buffer.test.cpp
@@ -40,21 +40,21 @@ public:
     using input_buffer::reset;
 
     auto do_require_input(size_type const requiredSize) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         require_input_calls += 1;
         last_require_input_param = requiredSize;
         return dp::errc::end_of_stream;
     }
     auto do_discard_input(size_type const amount) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         discard_input_calls += 1;
         last_discard_input_param = amount;
         return dp::errc::end_of_stream;
     }
     auto do_bulk_read(std::byte *const dest, std::size_t const size) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         bulk_read_calls += 1;
         last_bulk_read_param0 = dest;

--- a/src/dplx/dp/streams/output_buffer.hpp
+++ b/src/dplx/dp/streams/output_buffer.hpp
@@ -100,7 +100,7 @@ public:
 
     auto ensure_size(size_type const requestedSize) noexcept -> result<void>
     {
-        result<void> rx = oc::success();
+        result<void> rx = outcome::success();
         if (mOutputBufferSize < requestedSize)
         {
             rx = do_grow(requestedSize);
@@ -126,7 +126,7 @@ public:
     {
         if (bytesSize == 0U) [[unlikely]]
         {
-            return oc::success();
+            return outcome::success();
         }
         if (mOutputBufferSize > 0U) [[likely]]
         {
@@ -141,7 +141,7 @@ public:
         }
         if (bytesSize == 0U)
         {
-            return oc::success();
+            return outcome::success();
         }
         return do_bulk_write(bytes, bytesSize);
     }
@@ -176,7 +176,7 @@ private:
             = 0;
     virtual auto do_sync_output() noexcept -> result<void>
     {
-        return oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dplx/dp/streams/output_buffer.test.cpp
+++ b/src/dplx/dp/streams/output_buffer.test.cpp
@@ -38,7 +38,7 @@ public:
     using output_buffer::reset;
 
     auto do_grow(size_type const requestedSize) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         grow_calls += 1;
         last_grow_param = requestedSize;
@@ -47,7 +47,7 @@ public:
 
     auto do_bulk_write(std::byte const *const bytes,
                        std::size_t const bytesSize) noexcept
-            -> dp::result<void> override
+            -> result<void> override
     {
         bulk_write_calls += 1;
         last_bulk_write_call_param0 = bytes;

--- a/src/dplx/dp/streams/void_stream.hpp
+++ b/src/dplx/dp/streams/void_stream.hpp
@@ -55,7 +55,7 @@ private:
         mTotalWritten += void_buffer_size - size();
         output_buffer::reset(static_cast<std::byte *>(mMemory),
                              sizeof(mMemory));
-        return oc::success();
+        return outcome::success();
     }
     auto do_bulk_write(std::byte const *, std::size_t toBeWritten) noexcept
             -> result<void> override
@@ -65,7 +65,7 @@ private:
         mTotalWritten += void_buffer_size + toBeWritten;
         output_buffer::reset(static_cast<std::byte *>(mMemory),
                              sizeof(mMemory));
-        return oc::success();
+        return outcome::success();
     }
 };
 

--- a/src/dplx/dp/tuple_def.hpp
+++ b/src/dplx/dp/tuple_def.hpp
@@ -118,7 +118,7 @@ struct tuple_def
     template <typename Fn>
     static inline auto mp_for_dots(Fn &&fn) -> result<void>
     {
-        result<void> rx = oc::success();
+        result<void> rx = outcome::success();
 
         [[maybe_unused]] bool failed
                 = (...

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
         {
             "kind": "git",
             "repository": "https://github.com/deeplex/vcpkg-registry",
-            "baseline": "25b7089cc89009464ea4401d10c5b7b84a162c11",
+            "baseline": "b2d35d84b617a07d18a234df7ceed3bed504c279",
             "packages": [
                 "concrete"
             ]


### PR DESCRIPTION

### Purpose
Unify the result type and related aliases accross deeplex libraries.
