### PR TITLE
feat: Add a function which copies an encoded item

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -51,6 +51,8 @@ AttributeMacros:
   - __capability
   - DPLX_ATTR_FORCE_INLINE
   - DPLX_ATTR_NO_UNIQUE_ADDRESS
+  - DPLX_ATTR_DP_DEPRECATED
+  - DPLX_ATTR_DP_DEPRECATED_
 BinPackArguments: true
 BinPackParameters: false
 BraceWrapping:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,11 +2,13 @@
 # cppcoreguidelines-avoid-magic-numbers aliases readability-magic-numbers
 # cppcoreguidelines-avoid-c-arrays aliases modernize-avoid-c-arrays
 # cppcoreguidelines-special-member-functions is overly explicit and verbose
+# clang-analyzer-core.uninitialized.Assign happens to choke on OUTCOME_TRY
 Checks: >
   boost-*,
   bugprone-*,
     -bugprone-easily-swappable-parameters,
   clang-analyzer-*,
+    -clang-analyzer-core.uninitialized.Assign,
   clang-diagnostic-*,
   cppcoreguidelines-*,
     -cppcoreguidelines-avoid-c-arrays,

--- a/sources.cmake
+++ b/sources.cmake
@@ -16,6 +16,8 @@ dplx_target_sources(deeppack
         dp/codecs/uuid
 
         dp/items/skip_item
+
+        dp/streams/dynamic_memory_output_stream
 )
 
 dplx_target_sources(deeppack

--- a/sources.cmake
+++ b/sources.cmake
@@ -15,6 +15,7 @@ dplx_target_sources(deeppack
         dp/codecs/system_error2
         dp/codecs/uuid
 
+        dp/items/copy_item
         dp/items/skip_item
 
         dp/streams/dynamic_memory_output_stream

--- a/src/dplx/dp/config.hpp
+++ b/src/dplx/dp/config.hpp
@@ -12,9 +12,23 @@
 #include <dplx/dp/detail/config.hpp>
 #endif
 
+// NOLINTBEGIN(modernize-macro-to-enum)
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+
 #if !defined(DPLX_DP_DISABLE_WORKAROUNDS)
 #define DPLX_DP_DISABLE_WORKAROUNDS 0
 #endif
 #if !defined(DPLX_DP_FLAG_OUTDATED_WORKAROUNDS)
 #define DPLX_DP_FLAG_OUTDATED_WORKAROUNDS 0
 #endif
+
+#if DPLX_DP_SILENCE_DEPRECATION_WARNINGS
+#define DPLX_ATTR_DP_DEPRECATED
+#define DPLX_ATTR_DP_DEPRECATED_(reason)
+#else
+#define DPLX_ATTR_DP_DEPRECATED          [[deprecated]]
+#define DPLX_ATTR_DP_DEPRECATED_(reason) [[deprecated(reason)]]
+#endif
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
+// NOLINTEND(modernize-macro-to-enum)

--- a/src/dplx/dp/items/copy_item.cpp
+++ b/src/dplx/dp/items/copy_item.cpp
@@ -1,0 +1,260 @@
+
+// Copyright Henrik Steffen Gaßmann 2023
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/dp/items/copy_item.hpp"
+
+#include <cstddef>
+#include <new>
+
+#include <boost/container/small_vector.hpp>
+
+#include <dplx/dp/items/emit_core.hpp>
+#include <dplx/dp/items/parse_context.hpp>
+#include <dplx/dp/items/parse_core.hpp>
+#include <dplx/dp/streams/output_buffer.hpp>
+
+namespace dplx::dp
+{
+
+namespace detail
+{
+
+DPLX_ATTR_FORCE_INLINE static auto
+small_buffer_copy(input_buffer &in,
+                  std::size_t amount,
+                  output_buffer &out) noexcept -> result<void>
+{
+    DPLX_TRY(out.ensure_size(amount));
+    DPLX_TRY(in.bulk_read(out.data(), amount));
+    out.commit_written(amount);
+    return outcome::success();
+}
+DPLX_ATTR_FORCE_INLINE static auto
+bulk_copy(input_buffer &in, std::uint64_t amount, output_buffer &out) noexcept
+        -> result<void>
+{
+    do
+    {
+        // dance around gcc's useless cast warning 🤬
+#if SIZE_MAX == UINT64_MAX
+        std::size_t chunk(amount);
+#else
+        std::size_t chunk = amount > SIZE_MAX
+                                  ? SIZE_MAX
+                                  : static_cast<std::size_t>(amount);
+#endif
+        DPLX_TRY(out.ensure_size(chunk));
+        chunk = std::min(chunk, out.size());
+        DPLX_TRY(in.bulk_read(out.data(), chunk));
+        out.commit_written(chunk);
+        amount -= chunk;
+
+    } while (amount > 0U);
+    return outcome::success();
+}
+
+DPLX_ATTR_FORCE_INLINE static auto copy_special_break_to(parse_context &ctx,
+                                                         output_buffer &out)
+        -> result<void>
+{
+
+    ctx.in.discard_buffered(1U);
+    DPLX_TRY(out.ensure_size(1U));
+    *out.data() = static_cast<std::byte>(type_code::special_break);
+    out.commit_written(1U);
+    return outcome::success();
+}
+
+static auto copy_binary_or_text_to(parse_context &ctx,
+                                   item_head const &item,
+                                   output_buffer &out) -> result<void>
+{
+    if (!item.indefinite()) [[likely]]
+    {
+        return detail::bulk_copy(ctx.in, item.value, out);
+    }
+
+    for (;;)
+    {
+        item_head chunkInfo; // NOLINT(cppcoreguidelines-pro-type-member-init)
+        if (auto &&parseHeadRx = dp::peek_item_head(ctx);
+            parseHeadRx.has_value()) [[likely]]
+        {
+            chunkInfo = parseHeadRx.assume_value();
+        }
+        else
+        {
+            return static_cast<decltype(parseHeadRx) &&>(parseHeadRx)
+                    .assume_error();
+        }
+
+        if (chunkInfo.is_special_break())
+        {
+            DPLX_TRY(detail::copy_special_break_to(ctx, out));
+            break;
+        }
+        if (chunkInfo.type != item.type || chunkInfo.indefinite())
+        {
+            return errc::invalid_indefinite_subitem;
+        }
+
+        DPLX_TRY(detail::bulk_copy(
+                ctx.in, chunkInfo.encoded_length + chunkInfo.value, out));
+    }
+    return outcome::success();
+}
+
+} // namespace detail
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+auto copy_item_to(parse_context &ctx, output_buffer &out) noexcept
+        -> result<void>
+{
+    // note that for every valid item head the following holds:
+    // encoded_length < minimum_output_buffer_size
+
+    constexpr int majorTypeBitOffset = 5;
+    constexpr std::size_t numStackItems = 64;
+
+    boost::container::small_vector<item_head, numStackItems> stack;
+    auto pushItemHead = [&ctx, &out, &stack](item_head head) -> result<void>
+    {
+        try
+        {
+            DPLX_TRY(detail::small_buffer_copy(ctx.in, head.encoded_length,
+                                               out));
+            stack.push_back(head);
+            return outcome::success();
+        }
+        catch (std::bad_alloc const &)
+        {
+            return errc::not_enough_memory;
+        }
+    };
+
+    if (auto &&parseHeadRx = dp::peek_item_head(ctx); parseHeadRx.has_error())
+    {
+        return static_cast<decltype(parseHeadRx) &&>(parseHeadRx)
+                .assume_error();
+    }
+    else // NOLINT(readability-else-after-return)
+    {
+        DPLX_TRY(pushItemHead(parseHeadRx.assume_value()));
+    }
+
+    do
+    {
+        auto &item = stack.back();
+        switch (static_cast<std::uint8_t>(item.type) >> majorTypeBitOffset)
+        {
+        case static_cast<unsigned>(type_code::special) >> majorTypeBitOffset:
+            if (item.indefinite())
+            {
+                // special break has no business being here.
+                return errc::item_type_mismatch;
+            }
+            [[fallthrough]];
+        case static_cast<unsigned>(type_code::posint) >> majorTypeBitOffset:
+        case static_cast<unsigned>(type_code::negint) >> majorTypeBitOffset:
+            stack.pop_back();
+            break;
+
+        case static_cast<unsigned>(type_code::binary) >> majorTypeBitOffset:
+        case static_cast<unsigned>(type_code::text) >> majorTypeBitOffset:
+        {
+            // neither finite nor indefinite binary/text items can be nested
+            DPLX_TRY(detail::copy_binary_or_text_to(ctx, item, out));
+            stack.pop_back();
+            break;
+        }
+
+        case static_cast<unsigned>(type_code::array) >> majorTypeBitOffset:
+        {
+            if (item.value == 0)
+            {
+                stack.pop_back();
+                break;
+            }
+
+            bool const indefinite = item.indefinite();
+            // for indefinite arrays we keep item.value safely at 0x1f != 0
+            item.value -= static_cast<unsigned>(!indefinite);
+
+            // item reference can be invalidated by push back
+            DPLX_TRY(item_head subItem, dp::peek_item_head(ctx));
+            if (!indefinite || !subItem.is_special_break()) [[likely]]
+            {
+                DPLX_TRY(pushItemHead(subItem));
+            }
+            else [[unlikely]]
+            {
+                // special break => it's over
+                DPLX_TRY(detail::copy_special_break_to(ctx, out));
+                stack.pop_back();
+            }
+            break;
+        }
+
+        case static_cast<unsigned>(type_code::map) >> majorTypeBitOffset:
+        {
+            if (item.value == 0)
+            {
+                stack.pop_back();
+                break;
+            }
+
+            auto const rawFlags = static_cast<unsigned>(item.flags);
+            auto const indefinite
+                    = (rawFlags
+                       & static_cast<unsigned>(item_head::flag::indefinite))
+                   != 0U;
+            // we abuse item.flags to track whether to expect a value or key
+            // code == 0b0x  =>  next item is a key
+            // code == 0b1x  =>  next item is a value, therefore decrement kv
+            // ctr
+            auto const decr = (rawFlags >> 1);
+            item.flags = static_cast<item_head::flag>(rawFlags ^ 2U);
+
+            // for indefinite maps we keep item.value safely at 0x1f != 0
+            item.value -= decr & static_cast<unsigned>(!indefinite);
+
+            // item reference can be invalidated by push back
+            DPLX_TRY(item_head subItem, dp::peek_item_head(ctx));
+            if (!indefinite || !subItem.is_special_break()) [[likely]]
+            {
+                DPLX_TRY(pushItemHead(subItem));
+            }
+            else [[unlikely]]
+            {
+                if (decr != 0U)
+                {
+                    // uhhh, an odd number of items in a map
+                    return errc::item_type_mismatch;
+                }
+                // special break => it's over
+                DPLX_TRY(detail::copy_special_break_to(ctx, out));
+                stack.pop_back();
+            }
+
+            break;
+        }
+
+        case static_cast<unsigned>(type_code::tag) >> majorTypeBitOffset:
+        {
+            DPLX_TRY(item, dp::peek_item_head(ctx));
+            DPLX_TRY(detail::small_buffer_copy(ctx.in, item.encoded_length,
+                                               out));
+            break;
+        }
+        }
+
+    } while (!stack.empty());
+
+    return outcome::success();
+}
+
+} // namespace dplx::dp

--- a/src/dplx/dp/items/copy_item.hpp
+++ b/src/dplx/dp/items/copy_item.hpp
@@ -1,0 +1,19 @@
+
+// Copyright Henrik Steffen Gaßmann 2023
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <dplx/dp/disappointment.hpp>
+#include <dplx/dp/fwd.hpp>
+
+namespace dplx::dp
+{
+
+auto copy_item_to(parse_context &ctx, dp::output_buffer &out) noexcept
+        -> result<void>;
+
+} // namespace dplx::dp

--- a/src/dplx/dp/items/copy_item.test.cpp
+++ b/src/dplx/dp/items/copy_item.test.cpp
@@ -1,0 +1,190 @@
+
+// Copyright Henrik Steffen Gaßmann 2023
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/dp/items/copy_item.hpp"
+
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <dplx/dp/streams/dynamic_memory_output_stream.hpp>
+
+#include "blob_matcher.hpp"
+#include "core_samples.hpp"
+#include "item_sample_rt.hpp"
+#include "range_generator.hpp"
+#include "test_input_stream.hpp"
+#include "test_utils.hpp"
+#include "yaml_sample_generator.hpp"
+
+namespace dp_tests
+{
+
+TEST_CASE("copy_item_to can copy posint items")
+{
+    auto const sample = GENERATE(borrowed_range(posint_samples));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded_bytes());
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy negint items")
+{
+    auto const sample = GENERATE(borrowed_range(negint_samples));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded_bytes());
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy blob items")
+{
+    item_sample_rt<YAML::Binary> const sample
+            = GENERATE(load_samples_from_yaml<YAML::Binary>("blobs.yaml",
+                                                            "definite blobs"));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded);
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy indefinite blob items")
+{
+    item_sample_rt<YAML::Binary> const sample
+            = GENERATE(load_samples_from_yaml<YAML::Binary>(
+                    "blobs.yaml", "indefinite blobs"));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded);
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy int array items")
+{
+    item_sample_rt<std::vector<int>> const sample
+            = GENERATE(load_samples_from_yaml<std::vector<int>>("arrays.yaml",
+                                                                "int arrays"));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded_bytes());
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy indefinite int array items")
+{
+    item_sample_rt<std::vector<int>> const sample
+            = GENERATE(load_samples_from_yaml<std::vector<int>>(
+                    "arrays.yaml", "indefinite int arrays"));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded_bytes());
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy int map items")
+{
+    item_sample_rt<std::vector<std::pair<int, int>>> const sample
+            = GENERATE(load_samples_from_yaml<std::vector<std::pair<int, int>>>(
+                    "maps.yaml", "int maps"));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded_bytes());
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy indefinite int map items")
+{
+    item_sample_rt<std::vector<std::pair<int, int>>> const sample
+            = GENERATE(load_samples_from_yaml<std::vector<std::pair<int, int>>>(
+                    "maps.yaml", "indefinite int maps"));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded_bytes());
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy float single items")
+{
+    auto const sample = GENERATE(borrowed_range(float_single_samples));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded_bytes());
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+TEST_CASE("copy_item_to can copy float double items")
+{
+    auto const sample = GENERATE(borrowed_range(float_double_samples));
+    INFO(sample);
+
+    simple_test_parse_context ctx(sample.encoded_bytes());
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> out;
+
+    REQUIRE(dp::copy_item_to(ctx.as_parse_context(), out));
+
+    CHECK(ctx.stream.input_size() == 0U);
+    auto const written = std::move(out).written();
+    CHECK_BLOB_EQ(written, sample.encoded_bytes());
+}
+
+} // namespace dp_tests

--- a/src/dplx/dp/items/parse_core.hpp
+++ b/src/dplx/dp/items/parse_core.hpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstdint>
 
+#include <dplx/dp/config.hpp>
 #include <dplx/dp/detail/bit.hpp>
 #include <dplx/dp/disappointment.hpp>
 #include <dplx/dp/items/encoded_item_head_size.hpp>
@@ -75,82 +76,12 @@ inline constexpr std::uint8_t item_type_mask = 0b111'00000U;
 inline constexpr std::uint8_t item_inline_info_mask = 0b000'11111U;
 inline constexpr unsigned item_var_int_coding_threshold = 27U;
 
-inline auto parse_item_head_speculative(parse_context &ctx) noexcept
-        -> result<item_head>
+template <bool speculative>
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+inline auto do_parse_item_head(parse_context &ctx) noexcept -> result<item_head>
 {
     std::byte const *const encoded = ctx.in.data();
-    result<item_head> rx(item_head{
-            .type = static_cast<type_code>(static_cast<std::uint8_t>(*encoded)
-                                           & item_type_mask),
-            .flags = item_head::flag::none,
-            .encoded_length = 1,
-            .value
-            = static_cast<std::uint64_t>(static_cast<std::uint8_t>(*encoded)
-                                         & item_inline_info_mask),
-    });
-    item_head &info = rx.assume_value();
-
-    if (info.value <= inline_value_max)
-    {
-        // this is always well formed
-    }
-    else if (info.value <= item_var_int_coding_threshold) [[likely]]
-    {
-        auto const sizeBytesPower = static_cast<signed char>(
-                static_cast<unsigned>(info.value) - (inline_value_max + 1U));
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        auto const encodedValue = detail::load<std::uint64_t>(encoded + 1);
-
-        // 8B value => shift by  0 (0b00'0000)
-        // 4B value => shift by 32 (0b10'0000)
-        // 2B value => shift by 48 (0b11'0000)
-        // 1B value => shift by 56 (0b11'1000)
-        constexpr unsigned varLenPattern = 0b0011'1000U;
-        unsigned char const varLenShift = (varLenPattern << sizeBytesPower)
-                                        & (digits_v<std::uint64_t> - 1U);
-
-        info.encoded_length = 1U + (1U << sizeBytesPower);
-        info.value = encodedValue >> varLenShift;
-
-        if (info.type == type_code::special
-            && sizeBytesPower == 0
-            // encoding type 7 (special) values [0..32] with two bytes is
-            // forbidden as per RFC8949 section 3.3
-            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-            && info.value < 0x20) [[unlikely]]
-        {
-            rx = errc::invalid_additional_information;
-        }
-    }
-    // the one value which may also be well formed
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    else if (info.value == 31U
-             // every type with one of these bits set has a meaningful value,
-             // except for tag
-             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-             && (static_cast<unsigned char>(info.type) & 0b110'00000U) != 0U
-             && info.type != type_code::tag)
-    {
-        info.make_indefinite();
-    }
-    else // 27 < addInfo < 31 || indefinite integer or tag
-    {
-        rx = errc::invalid_additional_information;
-    }
-
-    if (rx.has_value())
-    {
-        ctx.in.discard_buffered(info.encoded_length);
-    }
-    return rx;
-}
-
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-inline auto parse_item_head_safe(parse_context &ctx) noexcept
-        -> result<item_head>
-{
-    assert(!ctx.in.empty());
-    std::byte const indicator = *ctx.in.data();
+    std::byte const indicator = *encoded;
     result<item_head> rx(item_head{
             .type = static_cast<type_code>(static_cast<std::uint8_t>(indicator)
                                            & item_type_mask),
@@ -168,42 +99,72 @@ inline auto parse_item_head_safe(parse_context &ctx) noexcept
     }
     else if (info.value <= item_var_int_coding_threshold) [[likely]]
     {
-        auto const bytePower = info.value - (inline_value_max + 1U);
-        info.encoded_length = 1U + (1U << bytePower);
-
-        if (result<void> requireInputRx
-            = ctx.in.require_input(info.encoded_length);
-            requireInputRx.has_value())
+        auto const sizeBytesPower = static_cast<signed char>(
+                static_cast<unsigned>(info.value) - (inline_value_max + 1U));
+        if constexpr (speculative)
         {
             // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-            std::byte const *const payload = ctx.in.data() + 1;
-            switch (bytePower)
+            auto const encodedValue = detail::load<std::uint64_t>(encoded + 1);
+
+            // 8B value => shift by  0 (0b00'0000)
+            // 4B value => shift by 32 (0b10'0000)
+            // 2B value => shift by 48 (0b11'0000)
+            // 1B value => shift by 56 (0b11'1000)
+            constexpr unsigned varLenPattern = 0b0011'1000U;
+            unsigned char const varLenShift = (varLenPattern << sizeBytesPower)
+                                            & (digits_v<std::uint64_t> - 1U);
+
+            info.encoded_length = 1U + (1U << sizeBytesPower);
+            info.value = encodedValue >> varLenShift;
+
+            if (info.type == type_code::special
+                && sizeBytesPower == 0
+                // encoding type 7 (special) values [0..32] with two bytes is
+                // forbidden as per RFC8949 section 3.3
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+                && info.value < 0x20) [[unlikely]]
             {
-            case 0U:
-                info.value = static_cast<std::uint64_t>(*payload);
-                if (info.type == type_code::special
-                    // encoding type 7 (special) values [0..32] with two bytes
-                    // is forbidden as per RFC8949 section 3.3
-                    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-                    && info.value < 0x20) [[unlikely]]
-                {
-                    rx = errc::invalid_additional_information;
-                }
-                break;
-            case 1U:
-                info.value = detail::load<std::uint16_t>(payload);
-                break;
-            case 2U:
-                info.value = detail::load<std::uint32_t>(payload);
-                break;
-            case 3U:
-                info.value = detail::load<std::uint64_t>(payload);
-                break;
+                rx = errc::invalid_additional_information;
             }
         }
         else
         {
-            rx = static_cast<result<void> &&>(requireInputRx).as_failure();
+            info.encoded_length = 1U + (1U << sizeBytesPower);
+
+            if (result<void> requireInputRx
+                = ctx.in.require_input(info.encoded_length);
+                requireInputRx.has_value())
+            {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                std::byte const *const payload = ctx.in.data() + 1;
+                switch (sizeBytesPower)
+                {
+                case 0U:
+                    info.value = static_cast<std::uint64_t>(*payload);
+                    if (info.type == type_code::special
+                        // encoding type 7 (special) values [0..32] with two
+                        // bytes is forbidden as per RFC8949 section 3.3
+                        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+                        && info.value < 0x20) [[unlikely]]
+                    {
+                        rx = errc::invalid_additional_information;
+                    }
+                    break;
+                case 1U:
+                    info.value = detail::load<std::uint16_t>(payload);
+                    break;
+                case 2U:
+                    info.value = detail::load<std::uint32_t>(payload);
+                    break;
+                case 3U:
+                    info.value = detail::load<std::uint64_t>(payload);
+                    break;
+                }
+            }
+            else
+            {
+                rx = static_cast<result<void> &&>(requireInputRx).as_failure();
+            }
         }
     }
     // the one value which may also be well formed
@@ -214,7 +175,6 @@ inline auto parse_item_head_safe(parse_context &ctx) noexcept
              // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
              && (static_cast<unsigned char>(info.type) & 0b110'00000U) != 0U
              && info.type != type_code::tag)
-
     {
         info.make_indefinite();
     }
@@ -230,6 +190,18 @@ inline auto parse_item_head_safe(parse_context &ctx) noexcept
     return rx;
 }
 
+DPLX_ATTR_DP_DEPRECATED inline auto
+parse_item_head_speculative(parse_context &ctx) noexcept -> result<item_head>
+{
+    return detail::do_parse_item_head<true>(ctx);
+}
+
+DPLX_ATTR_DP_DEPRECATED inline auto
+parse_item_head_safe(parse_context &ctx) noexcept -> result<item_head>
+{
+    return detail::do_parse_item_head<false>(ctx);
+}
+
 } // namespace dplx::dp::detail
 
 namespace dplx::dp
@@ -243,9 +215,9 @@ inline auto parse_item_head(parse_context &ctx) noexcept -> result<item_head>
     }
     if (ctx.in.size() >= detail::var_uint_max_size)
     {
-        return detail::parse_item_head_speculative(ctx);
+        return detail::do_parse_item_head<true>(ctx);
     }
-    return detail::parse_item_head_safe(ctx);
+    return detail::do_parse_item_head<false>(ctx);
 }
 
 inline auto expect_item_head(parse_context &ctx,

--- a/src/dplx/dp/items/parse_core.test.cpp
+++ b/src/dplx/dp/items/parse_core.test.cpp
@@ -127,8 +127,8 @@ TEST_CASE("parse_item_head_speculative can parse basic item_heads")
 
     simple_test_parse_context ctx(as_bytes(std::span(sample.encoded)));
 
-    auto const parsed
-            = dp::detail::do_parse_item_head<true>(ctx.as_parse_context());
+    auto const parsed = dp::detail::do_parse_item_head<true, true>(
+            ctx.as_parse_context());
     REQUIRE(parsed);
     auto const &head = parsed.assume_value();
 
@@ -145,8 +145,8 @@ TEST_CASE("parse_item_head_safe can parse basic item_heads")
     {
         simple_test_parse_context ctx(as_bytes(std::span(sample.encoded)));
 
-        auto const parsed
-                = dp::detail::do_parse_item_head<false>(ctx.as_parse_context());
+        auto const parsed = dp::detail::do_parse_item_head<false, true>(
+                ctx.as_parse_context());
         REQUIRE(parsed);
         auto const &head = parsed.assume_value();
 
@@ -157,8 +157,8 @@ TEST_CASE("parse_item_head_safe can parse basic item_heads")
     {
         simple_test_parse_context ctx(sample.encoded_bytes());
 
-        auto const parsed
-                = dp::detail::do_parse_item_head<false>(ctx.as_parse_context());
+        auto const parsed = dp::detail::do_parse_item_head<false, true>(
+                ctx.as_parse_context());
         REQUIRE(parsed);
         auto const &head = parsed.assume_value();
 

--- a/src/dplx/dp/items/parse_core.test.cpp
+++ b/src/dplx/dp/items/parse_core.test.cpp
@@ -128,7 +128,7 @@ TEST_CASE("parse_item_head_speculative can parse basic item_heads")
     simple_test_parse_context ctx(as_bytes(std::span(sample.encoded)));
 
     auto const parsed
-            = dp::detail::parse_item_head_speculative(ctx.as_parse_context());
+            = dp::detail::do_parse_item_head<true>(ctx.as_parse_context());
     REQUIRE(parsed);
     auto const &head = parsed.assume_value();
 
@@ -146,7 +146,7 @@ TEST_CASE("parse_item_head_safe can parse basic item_heads")
         simple_test_parse_context ctx(as_bytes(std::span(sample.encoded)));
 
         auto const parsed
-                = dp::detail::parse_item_head_safe(ctx.as_parse_context());
+                = dp::detail::do_parse_item_head<false>(ctx.as_parse_context());
         REQUIRE(parsed);
         auto const &head = parsed.assume_value();
 
@@ -158,7 +158,7 @@ TEST_CASE("parse_item_head_safe can parse basic item_heads")
         simple_test_parse_context ctx(sample.encoded_bytes());
 
         auto const parsed
-                = dp::detail::parse_item_head_safe(ctx.as_parse_context());
+                = dp::detail::do_parse_item_head<false>(ctx.as_parse_context());
         REQUIRE(parsed);
         auto const &head = parsed.assume_value();
 

--- a/src/dplx/dp/streams/dynamic_memory_output_stream.cpp
+++ b/src/dplx/dp/streams/dynamic_memory_output_stream.cpp
@@ -1,0 +1,16 @@
+
+// Copyright Henrik Steffen Gaßmann 2023
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/dp/streams/dynamic_memory_output_stream.hpp"
+
+namespace dplx::dp
+{
+
+// NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor)
+template class dynamic_memory_output_stream<std::allocator<std::byte>>;
+
+} // namespace dplx::dp

--- a/src/dplx/dp/streams/dynamic_memory_output_stream.hpp
+++ b/src/dplx/dp/streams/dynamic_memory_output_stream.hpp
@@ -1,0 +1,120 @@
+
+// Copyright Henrik Steffen Gaßmann 2023
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include <boost/container/small_vector.hpp>
+#include <boost/container/vector.hpp>
+
+#include <dplx/cncr/math_supplement.hpp>
+
+#include <dplx/dp/cpos/container.hpp>
+#include <dplx/dp/fwd.hpp>
+#include <dplx/dp/streams/output_buffer.hpp>
+
+namespace dplx::dp
+{
+
+template <typename Allocator = std::allocator<std::byte>>
+// the class is final and none of its base classes have public destructors
+// NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor)
+class dynamic_memory_output_stream final : public output_buffer
+{
+    static constexpr std::size_t page_size = 4096U;
+    using alloc_traits = std::allocator_traits<Allocator>;
+
+    using buffer_type = std::vector<
+            std::byte,
+            typename alloc_traits::template rebind_alloc<std::byte>>;
+
+    buffer_type mBuffer{};
+
+public:
+    constexpr dynamic_memory_output_stream() noexcept(noexcept(buffer_type()))
+            = default;
+
+    explicit dynamic_memory_output_stream(buffer_type buffer) noexcept
+        : output_buffer(buffer.data(), buffer.size())
+        , mBuffer(std::move(buffer))
+    {
+    }
+    explicit dynamic_memory_output_stream(Allocator const &alloc) noexcept
+        : output_buffer()
+        , mBuffer(alloc)
+    {
+    }
+
+    [[nodiscard]] auto written() const &noexcept -> std::span<std::byte const>
+    {
+        return std::span<std::byte const>(mBuffer).subspan(
+                0U, mBuffer.size() - size());
+    }
+    [[nodiscard]] auto written() &&noexcept -> buffer_type
+    {
+        mBuffer.resize(mBuffer.size() - size());
+        output_buffer::reset();
+        return std::move(mBuffer);
+    }
+    [[nodiscard]] auto written_size() const noexcept -> std::size_t
+    {
+        return mBuffer.size() - size();
+    }
+
+private:
+    auto do_grow(size_type const requestedSize) noexcept
+            -> result<void> override
+    try
+    {
+        auto const offset = static_cast<std::size_t>(data() - mBuffer.data());
+        mBuffer.resize(buffer_size_for(mBuffer.size() + requestedSize));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        output_buffer::reset(mBuffer.data() + offset, mBuffer.size() - offset);
+        return outcome::success();
+    }
+    catch (std::bad_alloc const &)
+    {
+        return system_error::errc::not_enough_memory;
+    }
+    auto do_bulk_write(std::byte const *const srcData,
+                       std::size_t const srcSize) noexcept
+            -> result<void> override
+    {
+        DPLX_TRY(dynamic_memory_output_stream::do_grow(srcSize));
+        std::memcpy(data(), srcData, srcSize);
+        commit_written(srcSize);
+        return outcome::success();
+    }
+
+    [[nodiscard]] static auto buffer_size_for(std::size_t required) noexcept
+            -> std::size_t
+    {
+        constexpr std::size_t overflowThreshold = SIZE_MAX / 3 * 2 - page_size;
+        if (required >= overflowThreshold) [[unlikely]]
+        {
+            return SIZE_MAX;
+        }
+
+        auto acc = page_size;
+        while (acc < required)
+        {
+            acc = cncr::round_up_p2(acc * 3 / 2, page_size);
+        }
+        return acc;
+    }
+};
+
+template <typename Allocator>
+dynamic_memory_output_stream(std::vector<std::byte, Allocator> buffer)
+        -> dynamic_memory_output_stream<Allocator>;
+
+extern template class dynamic_memory_output_stream<std::allocator<std::byte>>;
+
+} // namespace dplx::dp

--- a/src/dplx/dp/streams/dynamic_memory_output_stream.test.cpp
+++ b/src/dplx/dp/streams/dynamic_memory_output_stream.test.cpp
@@ -1,0 +1,74 @@
+
+// Copyright Henrik Steffen Gaßmann 2023
+//
+// Distributed under the Boost Software License, Version 1.0.
+//         (See accompanying file LICENSE or copy at
+//           https://www.boost.org/LICENSE_1_0.txt)
+
+#include "dplx/dp/streams/dynamic_memory_output_stream.hpp"
+
+#include <array>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <dplx/dp/detail/workaround.hpp>
+
+#include "blob_matcher.hpp"
+#include "test_utils.hpp"
+
+namespace dp_tests
+{
+
+TEST_CASE("dynamic_memory_output_stream should be default constructible")
+{
+    dp::dynamic_memory_output_stream<std::allocator<std::byte>> subject;
+    CHECK(subject.empty());
+    CHECK(subject.written_size() == 0U);
+    CHECK(subject.written().empty());
+
+    SECTION("and copyable")
+    {
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+        auto const copy = subject;
+        CHECK(copy.empty());
+        CHECK(copy.written_size() == 0U);
+        CHECK(copy.written().empty());
+    }
+    SECTION("and growable")
+    {
+        REQUIRE(subject.ensure_size(1U));
+        CHECK(!subject.empty());
+        CHECK(subject.data() != nullptr);
+    }
+    SECTION("and bulk_writable")
+    {
+        constexpr std::byte invalidItem{0xfe};
+        std::array<std::byte, 1U> storage{invalidItem};
+        CHECK(subject.bulk_write(storage.data(), storage.size()));
+        CHECK(subject.written_size() == storage.size());
+        CHECK_BLOB_EQ(subject.written(), storage);
+    }
+}
+
+TEST_CASE("dynamic_memory_output_stream can be constructed from an existing "
+          "vector")
+{
+    constexpr std::size_t preallocationSize = 127U;
+    std::vector<std::byte> existing(preallocationSize, std::byte{});
+    auto const *const memPtr = existing.data();
+    dp::dynamic_memory_output_stream subject(std::move(existing));
+
+    CHECK(subject.size() == preallocationSize);
+    CHECK(subject.data() == memPtr);
+    CHECK(subject.written_size() == 0U);
+    CHECK(existing.empty()); // NOLINT(bugprone-use-after-move)
+
+    existing = std::move(subject).written();
+
+    CHECK(existing.empty());
+    CHECK(existing.capacity() == preallocationSize);
+    CHECK(existing.data() == memPtr);
+    CHECK(subject.empty()); // NOLINT(bugprone-use-after-move)
+}
+
+} // namespace dp_tests


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the pull request.
Fixing miniscule documentation issues or typos is an exception to this rule.

I recommend removing these comments before submitting.

Please provide enough information so that others can review your pull request:
-->

### Purpose
<!--
Explain the **motivation** for making this change. What existing problem does
the pull request solve? This could be a short summary of the motivating issue.


You may remove this if you're fixing a typo.
-->

Resolves #18

### Solution Sketch
Use the same approach as `dp::skip_item`, but copy the item's bytes to the output stream instead of discarding them. This however was impossible to do with `dp::parse_item_head` which has been complemented with `dp::peek_item_head`. All item parsing code has been folded into a single function template in order to keep code duplication at a minimum.
